### PR TITLE
Add colored dots to difficulty ratings

### DIFF
--- a/src/models/addw1/repairs.md
+++ b/src/models/addw1/repairs.md
@@ -17,7 +17,7 @@ Keyboard replacement is simple and requires only a cross-head screwdriver.
 
 **Tools required:** Cross-head (Phillips) screwdriver    
 **Time estimate:** 10 minutes    
-**Difficulty:** Low    
+**Difficulty:** Easy <span style="color:green;">●</span>    
 **Screws:** 2 total - 2 x M2 (black)
 
 ### Steps to replace the keyboard:
@@ -59,7 +59,7 @@ Removing the cover is required to access the internal components. Prior to remov
 
 **Tools required:** Cross-head (Phillips) screwdriver    
 **Time estimate:** 10 minutes    
-**Difficulty:** Medium    
+**Difficulty:** Medium <span style="color:orange;">●</span>    
 **Screws:** 14 total - 12 x M2 perimeter (black); 2 x M2 keyboard (black)
 
 ### Steps to remove the bottom cover:
@@ -91,7 +91,7 @@ RAM acts as temporary storage for your computer. More RAM generally provides bet
 
 **Tools required:** Cross-head (Phillips) screwdriver    
 **Time estimate:** 15 minutes    
-**Difficulty:** Medium
+**Difficulty:** Medium <span style="color:orange;">●</span> 
 
 ### Steps to replace the RAM:
 
@@ -109,7 +109,7 @@ M.2 SSDs offer, at minimum, SATA III speeds and performance in a package about t
 
 **Tools required:** Cross-head (Phillips) screwdriver    
 **Time estimate:** 5 minutes    
-**Difficulty:** Medium
+**Difficulty:** Medium <span style="color:orange;">●</span> 
 
 ### Steps to replace the M.2 drive:
 
@@ -131,7 +131,7 @@ In rare cases, or after several years, it may be necessary to apply new thermal 
 
 **Tools required:** Cross-head (Phillips) screwdriver    
 **Time estimate:** 5 minutes    
-**Difficulty:** High
+**Difficulty:** High <span style="color:red;">●</span> 
 
 ### Steps to replace the fans/heatsink/thermal paste:
 
@@ -153,7 +153,7 @@ The CMOS battery supplies power to the Adder WS's CMOS chip. Changes you make to
 
 **Tools required:** Cross-head (Phillips) screwdriver    
 **Time estimate:** 5 minutes    
-**Difficulty:** Medium
+**Difficulty:** Medium <span style="color:orange;">●</span> 
 
 ### Steps to replace the CMOS battery:
 
@@ -174,7 +174,7 @@ The battery provides primary power whenever the system is unplugged.
 
 **Tools required:** Cross-head (Phillips) screwdriver    
 **Time estimate:** 5 minutes    
-**Difficulty:** Easy
+**Difficulty:** Easy <span style="color:green;">●</span>
 
 ### Steps to replace the external battery
 
@@ -187,7 +187,7 @@ Your Adder WS's WiFi and Bluetooth are both handled by the same module. It is a 
 
 **Tools required:** Cross-head (Phillips) screwdriver    
 **Time estimate:** 5 minutes    
-**Difficulty:** Medium
+**Difficulty:** Medium <span style="color:orange;">●</span> 
 
 ### Steps to replace the WiFi/Bluetooth module
 

--- a/src/models/lemp9/repairs.md
+++ b/src/models/lemp9/repairs.md
@@ -16,7 +16,7 @@ Removing the cover is required to access the internal components. Prior to remov
 
 **Tools required:** Cross-head (Phillips) screwdriver  
 **Time estimate:** 5 minutes  
-**Difficulty:** Easy  
+**Difficulty:** Easy <span style="color:green;">●</span>  
 **Screws:** 12 total
 
 ### Steps to remove the bottom cover:
@@ -34,7 +34,7 @@ The Lemur Pro 9 comes with 8GB of RAM soldered onto the motherboard, which canno
 
 **Tools required:** Cross-head (Phillips) screwdriver    
 **Time estimate:** 10 minutes    
-**Difficulty:** Medium
+**Difficulty:** Medium <span style="color:orange;">●</span>
 
 ### Steps to replace the RAM:
 
@@ -52,7 +52,7 @@ This model supports up to two M.2 SSDs. Both M.2 slots are size 2280, and both s
 
 **Tools required:** Cross-head (Phillips) screwdriver    
 **Time estimate:** 10 minutes    
-**Difficulty:** Medium
+**Difficulty:** Medium <span style="color:orange;">●</span>
 
 ### Steps to replace the M.2 drive:
 
@@ -77,7 +77,7 @@ Depending on your climate and the age of the machine, it may be necessary to app
 
 **Tools required:** Cross-head (Phillips) screwdriver    
 **Time estimate:** 20 minutes    
-**Difficulty:** High
+**Difficulty:** High <span style="color:red;">●</span>
 
 ### Steps to replace the fans/heatsink/thermal paste:
 
@@ -102,7 +102,7 @@ The battery provides primary power whenever the system is unplugged.
 
 **Tools required:** Cross-head (Phillips) screwdriver    
 **Time estimate:** 15 minutes    
-**Difficulty:** Medium
+**Difficulty:** Medium <span style="color:orange;">●</span>
 
 ### Steps to replace the main battery
 
@@ -120,7 +120,7 @@ The CMOS battery supplies power to the system's CMOS chip. UEFI settings and the
 
 **Tools required:** Cross-head (Phillips) screwdriver    
 **Time estimate:** 10 minutes    
-**Difficulty:** Medium
+**Difficulty:** Medium <span style="color:orange;">●</span>
 
 ### Steps to replace the CMOS battery:
 
@@ -140,7 +140,7 @@ Your system's WiFi and Bluetooth are both handled by the same module. It connect
 
 **Tools required:** Cross-head (Phillips) screwdriver    
 **Time estimate:** 10 minutes    
-**Difficulty:** Medium
+**Difficulty:** Medium <span style="color:orange;">●</span>
 
 ### Steps to replace the WiFi/Bluetooth module
 


### PR DESCRIPTION
This adds colors to the difficulty rating for each of the repair items. After discussion with the team, a colored bullet point looks nicer than coloring the word itself.

While adding these, I noticed that one entry said "Low" while two said "Easy", so I corrected that for consistency as well (this inconsistency had been carried over from the legacy Adder service manual.)