### PR TITLE
(oryp6) Correct screw count for battery

### DIFF
--- a/src/models/oryp6/img/battery-screws.jpg
+++ b/src/models/oryp6/img/battery-screws.jpg
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ed3d956c0f9266f631e087bfe598509cd2b0b43933dcb1d968571d007efd0ca5
-size 186765
+oid sha256:a594f867f431dd9a44acd8ae476ae332bdefdac954eccec860af1c5a69e6d10b
+size 186447

--- a/src/models/oryp6/repairs.md
+++ b/src/models/oryp6/repairs.md
@@ -153,7 +153,7 @@ The battery provides primary power whenever the system is unplugged.
 
 1. Follow the steps above to [remove the bottom cover](#removing-the-bottom-cover).
 2. If there is an M.2 SSD in the slot closest to the battery, follow the steps above to [remove the M.2 SSD](#replacing-an-m2nvme-ssd).
-3. The battery is held in by four of the bottom panel screws and one additional screw underneath the M.2 SSD. Remove the final screw, highlighted red below.
+3. The battery is held in by three of the bottom panel screws and two additional screws, one of which is underneath the M.2 SSD. Remove the two final screws, highlighted red below.
 
 ![Battery screws](./img/battery-screws.jpg)
 


### PR DESCRIPTION
There are three bottom panel screws and two additional screws, not four bottom panel screws and one additional screw.