### PR TITLE
Correct information about SATA support in M.2 slots

### DIFF
--- a/src/models/oryp6/README.md
+++ b/src/models/oryp6/README.md
@@ -38,7 +38,8 @@ The System76 Oryx Pro is a laptop with the following specifications:
     - Combined microphone & S/PDIF (optical) 3.5mm jack
     - HDMI, Mini DisplayPort, USB-C DisplayPort audio
 - Storage
-    - 2x M.2 (PCIe NVMe or SATA)
+    - 1x M.2 (PCIe NVMe or SATA)
+    - 1x M.2 (PCIe NVMe only)
     - MicroSD card reader
 - USB
     - 3x USB 3.2 Gen 1 Type-A

--- a/src/models/oryp6/repairs.md
+++ b/src/models/oryp6/repairs.md
@@ -88,7 +88,7 @@ The Oryx Pro 6 supports up to 64GB (2x32GB) of DDR4 SO-DIMMs running at 3200MHz.
 
 ## Replacing an M.2/NVMe SSD:
 
-This model supports up to two M.2 SSDs. Both M.2 slots are size 2280, and both slots support SATA III or PCIe NVMe Generation 3.
+This model supports up to two M.2 SSDs. Both M.2 slots are size 2280. The inner-most slot (closest to the battery) supports only PCIe NVMe Generation 3, and the outer-most slot (farthest away from the battery) supports either SATA III or PCIe NVMe Generation 3.
 
 **Tools required:** Cross-head (Phillips) screwdriver  
 **Time estimate:** 10 minutes  


### PR DESCRIPTION
This PR specifies that one M.2 slot supports SATA and NVMe, while the other slot only supports NVMe.