### PR TITLE
Correct information about SATA/NVMe compatibility

### DIFF
--- a/src/models/serw12/README.md
+++ b/src/models/serw12/README.md
@@ -40,7 +40,8 @@ The System76 Serval WS is a laptop with the following specifications:
     - Microphone 3.5mm jack
     - HDMI, Mini DisplayPort, USB-C DisplayPort audio
 - Storage
-    - 2x M.2 (PCIe NVMe or SATA)
+    - M.2 SSD (slot 1): PCIe NVMe Gen 2
+    - M.2 SSD (slot 2): PCIe NVMe Gen 3 or SATA III
     - 1x 2.5" 7mm (SATA)
     - MicroSD card reader
 - USB

--- a/src/models/serw12/repairs.md
+++ b/src/models/serw12/repairs.md
@@ -104,7 +104,7 @@ The Serval WS 12 supports up to 64GB (2x32GB) of DDR4 SO-DIMMs running at 3200MH
 
 ## Replacing an M.2/NVMe SSD:
 
-This model supports up to two M.2 SSDs. Both M.2 slots are size 2280, and both slots support SATA III or PCIe NVMe Generation 3.
+This model supports up to two M.2 SSDs. Both M.2 slots are size 2280. Slot 1 supports PCIe NVMe Generation 2, while Slot 2 supports either SATA III or PCIe NVMe Generation 3.
 
 **Tools required:** Cross-head (Phillips) screwdriver  
 **Time estimate:** 10 minutes  
@@ -119,6 +119,7 @@ This model supports up to two M.2 SSDs. Both M.2 slots are size 2280, and both s
 
 3. Remove the existing M.2 drive by pulling it out of the slot.
 4. Insert the new M.2 drive into the slot and hold it in place.
+    - The slot closest to the fan supports either PCIe NVMe Generation 3 or SATA III. The slot closest to the battery supports PCIe NVMe Generation 2 only. (PCIe NVMe Generation 3 drives will work at slower speeds in the Generation 2 slot.)
 5. Replace the retainer screw.
 
 ## Replacing the cooling system:


### PR DESCRIPTION
The serw12 only supports SATA in one of its slots, not both. Additionally, the slot that is NVMe-only is limited to PCIe Gen 2 (testing shows write speeds are unaffected but read speeds are about 50% slower.)

The reason I refer to the slower NVMe-only slot as "Slot 1" is because that's what is physically printed on the board, and I believe it would lead to confusion if we referred to them opposite what they are physically labeled.

The reason I state that Gen 3 drives will work at slower speeds in the Gen 2 slot is not to call attention to the slower speeds (although that's important too), but rather to alleviate concern about Gen 3 drive compatibility.