### PR TITLE
Correct image file extension/format to match link

### DIFF
--- a/src/models/meer5/img/m2-screw.jpg
+++ b/src/models/meer5/img/m2-screw.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9ca95c28ecedd4eeeafe11caacd2554ac7a7a44fb4f328029d01f39ceadf9477
+size 126430

--- a/src/models/meer5/img/m2-screw.png
+++ b/src/models/meer5/img/m2-screw.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b0a00e683d3d71429d002c8f90ca73d0eb228f855080dac8c28ea7a03ad6ef5d
-size 1200190

--- a/src/models/meer5/repairs.md
+++ b/src/models/meer5/repairs.md
@@ -1,6 +1,6 @@
 # Meerkat (Parts & Repairs)
 
-Several components in your Meerkat can be upgraded or replaced as necessary. Power the machine off, switch off the power supply, and unplug all peripherals before working with any internal components. Then, follow these step-by-step guides for instructions:
+Several components in your Meerkat can be upgraded or replaced as necessary. Power the machine off and unplug all peripherals before working with any internal components. Then, follow these step-by-step guides for instructions:
 
 - [Removing the bottom panel](#removing-the-bottom-panel)
 - [Replacing the M.2 drive](#replacing-the-m2-drive)
@@ -64,17 +64,17 @@ Your Meerkat supports up to 64GB (2x32GB) of RAM. The RAM sticks are DDR4 SODIMM
 
 ![RAM latch](./img/ram-latch.jpg)
 
-3. Once both latches are released, the RAM stick will pop up, pushed the spring tension from the RAM slot. This means that the RAM stick can be pulled backwards out of the slot.
+3. Once both latches are released, the RAM stick will pop up, pushed the spring tension from the RAM slot. This means the RAM stick can be pulled backwards out of the slot.
 
 ![Unlatched RAM](./img/unlatched-ram.jpg)
 
-4. To install a RAM stick, slide the stick into the slot at roughly the same angle it was sitting after the latches were released, then push the back edge of the RAM stick downwards so that the latches on the sides re-engage.
+4. To install a RAM stick, slide the stick into the slot at roughly the same angle it was sitting after the latches were released, then push the back edge of the RAM stick downwards so the latches on the sides re-engage.
 
 5. Replace the bottom panel.
 
 ## Adding/removing a 2.5" storage drive:
 
-If your Meerkat is the tall variety, it has a 2.5" drive bay built in to the bottom panel.
+If your Meerkat is the tall variety, it has a 2.5" drive bay built into the bottom panel.
 
 **Tools required:** Cross-head (Phillips) screwdriver  
 **Time estimate:** 10 minutes  


### PR DESCRIPTION
https://github.com/system76/tech-docs/pull/38 added the M.2 drive image in .png format, but linked to it in .jpg format, so it's currently not showing up (see [here](https://tech-docs.system76.com/models/meer5/repairs.html#replacing-the-m2-drive)). This PR updates the image to be in .jpg format, so it's smaller and shows up properly.

Also removed the words "switch off the power supply" since there is no switch on the Meerkat, and made a couple of very small grammatical improvements.