### PR TITLE
lemp10 & galp5 updates

### DIFF
--- a/src/models/galp5/README.md
+++ b/src/models/galp5/README.md
@@ -30,10 +30,10 @@ The System76 Galago Pro is a laptop with the following specifications:
 - Power
     - Intel-only model:
         - 65W (19V, 3.42A) AC adapter
-        - USB-C charging compatible
+        - USB-C charging compatible with 65W+ charger
     - NVIDIA + Intel model:
         - 90W (19V, 4.74A) AC adapter
-        - Not USB-C charging compatible
+        - USB-C charging compatible with 90W+ charger
     - Included AC adapter uses C5 (Cloverleaf) power cord
     - 49Wh 4-cell Lithium-Ion battery
 - Sound

--- a/src/models/lemp10/README.md
+++ b/src/models/lemp10/README.md
@@ -43,9 +43,8 @@ The System76 Lemur Pro is a laptop with the following specifications:
     - M.2 (PCIe NVMe Gen 3 or SATA) SSD-2
     - MicroSD card reader (RTS5227S)
 - USB
-    - 1x USB 3.1 (3.1 Gen 2) Type-A
     - 1x USB Type-C with Thunderbolt 4
-        - USB Power Delivery
+    - 1x USB 3.1 (3.1 Gen 2) Type-A
     - 1x USB 3.0 (3.2 Gen 1) Type-A
 - Webcam
     - 1280x720 CCD camera

--- a/src/models/lemp10/README.md
+++ b/src/models/lemp10/README.md
@@ -45,7 +45,6 @@ The System76 Lemur Pro is a laptop with the following specifications:
 - USB
     - 1x USB 3.1 (3.1 Gen 2) Type-A
     - 1x USB Type-C with Thunderbolt 4
-        - DisplayPort 1.2 over USB-C
         - USB Power Delivery
     - 1x USB 3.0 (3.2 Gen 1) Type-A
 - Webcam

--- a/src/models/lemp10/README.md
+++ b/src/models/lemp10/README.md
@@ -44,7 +44,7 @@ The System76 Lemur Pro is a laptop with the following specifications:
     - MicroSD card reader (RTS5227S)
 - USB
     - 1x USB 3.1 (3.1 Gen 2) Type-A
-    - 1x USB 3.1 (3.1 Gen 2) Type-C
+    - 1x USB 3.1 (3.1 Gen 2) Type-C with Thunderbolt 4
         - DisplayPort 1.2 over USB-C
         - USB Power Delivery
     - 1x USB 3.0 (3.2 Gen 1) Type-A

--- a/src/models/lemp10/README.md
+++ b/src/models/lemp10/README.md
@@ -44,7 +44,7 @@ The System76 Lemur Pro is a laptop with the following specifications:
     - MicroSD card reader (RTS5227S)
 - USB
     - 1x USB 3.1 (3.1 Gen 2) Type-A
-    - 1x USB 3.1 (3.1 Gen 2) Type-C with Thunderbolt 4
+    - 1x USB Type-C with Thunderbolt 4
         - DisplayPort 1.2 over USB-C
         - USB Power Delivery
     - 1x USB 3.0 (3.2 Gen 1) Type-A

--- a/src/models/lemp10/img/ports-left.png
+++ b/src/models/lemp10/img/ports-left.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f9502da567ec4d91e64b5828071a0654e07b42e73cd534410f6b2cb2f528b554
-size 324279
+oid sha256:a06406fe18938e3f7bea998a6cf0425bd98089ded7a68b6418be3025e2cfc1cc
+size 311300

--- a/src/models/lemp9/img/ports-left.jpg
+++ b/src/models/lemp9/img/ports-left.jpg
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ce2e6646a14c89e5ad97332c4f1472cc03c49b9f05821839cec2ded97d0f0c4c
-size 57076
+oid sha256:9aec197260e16f5ab822c7fabceb6d77bb05166c5148f1ee3cd4867bb1748763
+size 69714


### PR DESCRIPTION
- Correction: galp5 NVIDIA can charge via USB-C, after all.
- Clarification: lemp10 has a Thunderbolt 4 port.
- Correction: lemp9/10 have a 3.1 Type-A port on the left side (not 3.0).