### PR TITLE
lemp10: correct part number & link for soldered RAM

### DIFF
--- a/src/models/lemp10/README.md
+++ b/src/models/lemp10/README.md
@@ -22,7 +22,7 @@ The System76 Lemur Pro is a laptop with the following specifications:
     - eDP 14.1" 1920x1080 LCD
     - HDMI and DisplayPort 1.2 over USB-C
 - Memory
-    - Channel 0: 8-GB on-board DDR4 [Samsung K4A8G085WC-BCWE](https://www.samsung.com/semiconductor/dram/ddr4/K4A8G085WC-BCWE/)
+    - Channel 0: 8-GB on-board DDR4 [K4AAG165WA-BCWE](https://www.samsung.com/semiconductor/dram/ddr4/K4AAG165WA-BCWE/) X 8
     - Channel 1: 8-GB/16-GB/32-GB DDR4 SO-DIMM @ 3200 MHz
 - Networking
     - M.2 PCIe/CNVi WiFi/Bluetooth

--- a/src/models/lemp10/README.md
+++ b/src/models/lemp10/README.md
@@ -22,7 +22,7 @@ The System76 Lemur Pro is a laptop with the following specifications:
     - eDP 14.1" 1920x1080 LCD
     - HDMI and DisplayPort 1.2 over USB-C
 - Memory
-    - Channel 0: 8-GB on-board DDR4 [Samsung K4AAG165WA-BCTD](https://www.samsung.com/semiconductor/dram/ddr4/K4AAG165WA-BCTD/)
+    - Channel 0: 8-GB on-board DDR4 [Samsung K4A8G085WC-BCWE](https://www.samsung.com/semiconductor/dram/ddr4/K4A8G085WC-BCWE/)
     - Channel 1: 8-GB/16-GB/32-GB DDR4 SO-DIMM @ 3200 MHz
 - Networking
     - M.2 PCIe/CNVi WiFi/Bluetooth

--- a/src/models/lemp10/README.md
+++ b/src/models/lemp10/README.md
@@ -22,7 +22,7 @@ The System76 Lemur Pro is a laptop with the following specifications:
     - eDP 14.1" 1920x1080 LCD
     - HDMI and DisplayPort 1.2 over USB-C
 - Memory
-    - Channel 0: 8-GB on-board DDR4 [K4AAG165WA-BCWE](https://www.samsung.com/semiconductor/dram/ddr4/K4AAG165WA-BCWE/) X 8
+    - Channel 0: 8-GB on-board DDR4 ([Samsung K4AAG165WA-BCWE](https://www.samsung.com/semiconductor/dram/ddr4/K4AAG165WA-BCWE/) x 8)
     - Channel 1: 8-GB/16-GB/32-GB DDR4 SO-DIMM @ 3200 MHz
 - Networking
     - M.2 PCIe/CNVi WiFi/Bluetooth


### PR DESCRIPTION
The linked part number was for a 16GB 2666MHz chip, so I changed it to this 8GB 3200MHz chip. It looks like [there was another possibilitiy](https://www.samsung.com/semiconductor/dram/ddr4/K4A8G085WC-BIWE/) so it might be worth verifying that I got it right. It's definitely not high priority though, since this corrects the size and speed discrepancy.