### PR TITLE
Add/correct DisplayPort versions for galp5/lemp10

### DIFF
--- a/src/models/galp5/README.md
+++ b/src/models/galp5/README.md
@@ -20,7 +20,7 @@ The System76 Galago Pro is a laptop with the following specifications:
     - Intel Iris Xe Graphics
     - (Optional) NVIDIA GeForce GTX 1650
     - eDP 14.1" 1920x1080 LCD
-    - HDMI and DisplayPort over USB-C
+    - HDMI and DisplayPort 1.4 over USB-C
 - Memory
     - Up to 64 (2x32GB) dual-channel DDR4 SO-DIMMs @ 3200 MHz
 - Networking

--- a/src/models/lemp10/README.md
+++ b/src/models/lemp10/README.md
@@ -20,7 +20,7 @@ The System76 Lemur Pro is a laptop with the following specifications:
     - Intel Iris Xe Graphics
     - GOP driver is recommended, VBT is provided
     - eDP 14.1" 1920x1080 LCD
-    - HDMI and DisplayPort 1.2 over USB-C
+    - HDMI and DisplayPort 1.4 over USB-C
 - Memory
     - Channel 0: 8-GB on-board DDR4 ([Samsung K4AAG165WA-BCWE](https://www.samsung.com/semiconductor/dram/ddr4/K4AAG165WA-BCWE/) x 8)
     - Channel 1: 8-GB/16-GB/32-GB DDR4 SO-DIMM @ 3200 MHz


### PR DESCRIPTION
While the galp5 Clevo manual does not specify a DisplayPort over USB-C version, and the lemp10 Clevo manual specifies DisplayPort 1.2 over USB-C, the Thunderbolt 4 specification includes DisplayPort 1.4. This PR updates the specs for these two models to specify DisplayPort 1.4 over USB-C, which matches the changes made to the tech specs on their product pages.