### PR TITLE
Add M.2/SATA limitations to 2.5" SATA section and tech specs overview

### DIFF
--- a/src/models/thelio-mega-r1.0/README.md
+++ b/src/models/thelio-mega-r1.0/README.md
@@ -55,6 +55,7 @@ The System76 Thelio Mega is a desktop with the following specifications:
     - 4x M.2 (PCIe Gen 4)
         - Backwards compatible with M.2 SATA and PCIe Gen 3.
     - 8x 2.5" SATA
+        - When using all four M.2 slots, some SATA ports will not function. See [Parts & Repairs](./repairs.md) for details.
 - USB
     - 7x USB 3.2 Gen 2 Type-A
     - 1x USB 3.2 Gen 2 Type-C

--- a/src/models/thelio-mega-r1.0/repairs.md
+++ b/src/models/thelio-mega-r1.0/repairs.md
@@ -59,7 +59,12 @@ The inner partition provides a brace for the outer case and helps hold the inter
 
 ## Adding/removing 2.5" storage drives:
 
-Thelio Mega r1.0 supports up to eight 2.5" SATA III drives.
+Thelio Mega r1.0 supports up to eight 2.5" SATA III drives. When using four M.2 drives, the following restrictions apply:
+
+- If the bottom right M.2 slot has a SATA drive installed, then 2.5" SATA ports 4 and 5 will be unavailable (leaving a maximum of six 2.5" SATA drives.)
+- If the bottom right M.2 slot has a PCIe NVMe drive installed, then 2.5" SATA ports 4, 5, 6, and 7 will be unavailable (leaving a maximum of four 2.5" SATA drives.)
+
+To use all eight 2.5" SATA III slots, use three or less M.2 drives and leave the bottom right M.2 slot empty. See [Replacing the M.2 drives](#replacing-the-m2-drives) to add, remove, or rearrange M.2 drives.
 
 **Tools required:** Cross-head (Phillips) screwdriver (optional)  
 **Time estimate:** 10 minutes  


### PR DESCRIPTION
This information was already listed in the M.2 drives section of the repairs page, but this was evidently not visible enough. This copies the information to the 2.5" drives section of the repairs page, and also adds a note on the tech specs overview.

(Feedback welcome about the tech specs; it seemed a little wordy to explain the entire thing there too, so I linked to the repairs page instead, but if this doesn't seem clear enough, we could just copy the info a third time.)