### PR TITLE
Correct number of memory channels

### DIFF
--- a/src/models/thelio-mira-r1.0/README.md
+++ b/src/models/thelio-mira-r1.0/README.md
@@ -47,7 +47,7 @@ The System76 Thelio Mira is a desktop with the following specifications:
         - [AMD Radeon RX 5700](https://www.amd.com/en/products/graphics/amd-radeon-rx-5700)
             - 3x DisplayPort 1.4, 1x HDMI 2.0b
 - Memory
-    - Up to 128GB (4x32GB) quad-channel ECC Unbuffered DDR4 DIMMs @ 3200 MHz
+    - Up to 128GB (4x32GB) dual-channel ECC Unbuffered DDR4 DIMMs @ 3200 MHz
     - Tested with the following RAM modules (may ship with other tested modules):
         - [Kingston HX432C16FB3/8](https://www.kingston.com/dataSheets/HX432C16FB3_8.pdf)
         - [Kingston HX432C16FB4/64](https://www.kingston.com/dataSheets/HX432C16FB3K4_64.pdf)


### PR DESCRIPTION
Confirmed this info in the user's manual for the motherboard: https://dlcdnets.asus.com/pub/ASUS/mb/SocketAM4/ROG_STRIX_X570-E_GAMING/E15826_ROG_STRIX_X570-E_GAMING_UM_v2_WEB.pdf 

![image](https://user-images.githubusercontent.com/7199422/111382281-65f3d280-866c-11eb-83c1-09412668fbf2.png)