### PR TITLE
Add note about work surface & revise battery removal steps

### DIFF
--- a/src/models/addw1/repairs.md
+++ b/src/models/addw1/repairs.md
@@ -22,7 +22,8 @@ Keyboard replacement is simple and requires only a cross-head screwdriver.
 
 ### Steps to replace the keyboard:
 
-1. Place the Adder WS lid-side-down.
+1. Place the machine lid-side down.
+    - Use a soft surface (such as a towel) to avoid scratches.
 2. Remove the 2 keyboard screws, indicated by the small keyboard icons.
 
 ![Keyboard screws](./img/keyboard-screws.png)
@@ -64,7 +65,8 @@ Removing the cover is required to access the internal components. Prior to remov
 
 ### Steps to remove the bottom cover:
 
-1. Place the Adder WS lid-side down.
+1. Place the machine lid-side down.
+    - Use a soft surface (such as a towel) to avoid scratches.
 2. Remove the external battery.
 3. [Remove the keyboard.](#replacing-the-keyboard)
 4. Remove the two screws underneath the keyboard labeled ‘M2’.
@@ -178,8 +180,10 @@ The battery provides primary power whenever the system is unplugged.
 
 ### Steps to replace the external battery
 
-1. Remove the two screws that hold the battery and then remove the battery.
-2. Place the new battery in and then add the two screws back.
+1. Place the machine lid-side down.
+    - Use a soft surface (such as a towel) to avoid scratches.
+2. Remove the two screws that hold the battery and then remove the battery.
+3. Place the new battery in and then add the two screws back.
 
 ## Replacing the wireless card
 

--- a/src/models/addw2/repairs.md
+++ b/src/models/addw2/repairs.md
@@ -22,11 +22,13 @@ The battery provides primary power whenever the system is unplugged.
 
 ### Steps to remove the battery:
 
-1. Remove the two battery screws, highlighted green below.
+1. Place the machine lid-side down.
+    - Use a soft surface (such as a towel) to avoid scratches.
+2. Remove the two battery screws, highlighted green below.
 
 ![Battery screws](./img/battery-screws.jpg)
 
-2. Lift the battery out of the chassis.
+3. Lift the battery out of the chassis.
 
 ## Removing the keyboard:
 
@@ -38,17 +40,19 @@ The keyboard (and built-in keyboard backlight) can be replaced using the instruc
 
 ### Steps to remove the keyboard:
 
-1. Remove the two keyboard screws.
+1. Place the machine lid-side down.
+    - Use a soft surface (such as a towel) to avoid scratches.
+2. Remove the two keyboard screws.
 
 ![Keyboard screws](./img/keyboard-screws.jpg)
 
-2. Open the lid slightly and place the machine on its side.
-3. Push the screwdriver into the keyboard push point (highlighted red above) until the keyboard pops out.
+3. Open the lid slightly and place the machine on its side.
+4. Push the screwdriver into the keyboard push point (highlighted red above) until the keyboard pops out.
 
 ![Keyboard push point](./img/keyboard-push-point.jpg)
 
-4. Set the machine upright and pull the keyboard out of the top case, starting from the top and working toward the bottom.
-5. Once freed, lift the bottom of the keyboard to see the ribbon cables. The larger ribbon cable is for the keyboard, while the smaller ribbon cable is for the keyboard backlight.
+5. Set the machine upright and pull the keyboard out of the top case, starting from the top and working toward the bottom.
+6. Once freed, lift the bottom of the keyboard to see the ribbon cables. The larger ribbon cable is for the keyboard, while the smaller ribbon cable is for the keyboard backlight.
     - If you are not replacing the keyboard, the keyboard can be flipped over onto the touchpad without disconnecting the ribbon cables.
 
 ![Keyboard ribbons](./img/keyboard-ribbons.jpg)

--- a/src/models/bonw14/repairs.md
+++ b/src/models/bonw14/repairs.md
@@ -23,11 +23,13 @@ Removing the cover is required to access the internal components. Prior to remov
 
 ### Steps to remove the bottom cover:
 
-1. Remove the 8 bottom panel screws (highlighted red below.)
+1. Place the machine lid-side down.
+    - Use a soft surface (such as a towel) to avoid scratches.
+2. Remove the 8 bottom panel screws (highlighted red below.)
 
 ![Bottom panel screws](./img/bottom-panel-screws.jpg)
 
-2. Slide the bottom panel away from the battery slot while lifting it up and off of the case (the panel detaches at a slight angle.)
+3. Slide the bottom panel away from the battery slot while lifting it up and off of the case (the panel detaches at a slight angle.)
 
 ## Removing the battery:
 
@@ -39,13 +41,15 @@ The battery provides primary power whenever the system is unplugged.
 
 ### Steps to remove the battery:
 
-1. Follow the steps above to [remove the bottom cover](#removing-the-bottom-cover). _(Removing the bottom cover is optional, but can make removing the battery significantly easier.)_
-2. Slide the locking battery slider (highlighted green below) to the "unlocked" position.
+1. Place the machine lid-side down.
+    - Use a soft surface (such as a towel) to avoid scratches.
+2. Follow the steps above to [remove the bottom cover](#removing-the-bottom-cover). _(Removing the bottom cover is optional, but can make removing the battery significantly easier.)_
+3. Slide the locking battery slider (highlighted green below) to the "unlocked" position.
 
 ![Battery sliders](./img/battery-sliders.jpg)
 
-3. Hold the spring-loaded battery slider (highlighted yellow above) in the "unlocked" position.
-4. Starting from the top, lift the battery up and out of the slot.
+4. Hold the spring-loaded battery slider (highlighted yellow above) in the "unlocked" position.
+5. Starting from the top, lift the battery up and out of the slot.
 
 ## Replacing the keyboard:
 

--- a/src/models/darp6/repairs.md
+++ b/src/models/darp6/repairs.md
@@ -21,29 +21,31 @@ The keyboard can be replaced using the instructions below. Removing the keyboard
 
 ### Steps to replace the keyboard:
 
-1. Remove the two keyboard screws (highlighted red below).
+1. Place the machine lid-side down.
+    - Use a soft surface (such as a towel) to avoid scratches.
+2. Remove the two keyboard screws (highlighted red below).
 
 ![Keyboard screws](./img/keyboard-screws.jpg)
 
-2. Open the lid slightly and place the machine on its side.
-3. Push the screwdriver into the keyboard push point (highlighted cyan above) until the keyboard pops out.
+3. Open the lid slightly and place the machine on its side.
+4. Push the screwdriver into the keyboard push point (highlighted cyan above) until the keyboard pops out.
 
 ![Keyboard push point](./img/keyboard-push-point.jpg)
 
-4. Set the machine back down and raise the keyboard away from the chassis. The larger ribbon cable is for the keyboard, while the smaller ribbon cable is for the keyboard backlight.
+5. Set the machine back down and raise the keyboard away from the chassis. The larger ribbon cable is for the keyboard, while the smaller ribbon cable is for the keyboard backlight.
 
 ![Keyboard ribbons](./img/keyboard-ribbons.jpg)
 
 _Note: Unplugging the ribbon cables is not required to remove the bottom cover._
 
-5. Flip the black latches upwards to free the ribbon cables.
-6. Pull the ribbon cables out of the connectors.
-7. Remove the keyboard and replace it with the new one.
-8. Carefully slide both ribbon cables into their connectors.
-9. Flip the black latches back into place to secure the ribbon cables.
-10. Place the keyboard back into position, starting with the tabs on the bottom edge.
-11. Secure the rest of the keyboard by pressing down on each of its edges.
-12. Turn the machine lid-side down again and replace the two keyboard screws.
+6. Flip the black latches upwards to free the ribbon cables.
+7. Pull the ribbon cables out of the connectors.
+8. Remove the keyboard and replace it with the new one.
+9. Carefully slide both ribbon cables into their connectors.
+10. Flip the black latches back into place to secure the ribbon cables.
+11. Place the keyboard back into position, starting with the tabs on the bottom edge.
+12. Secure the rest of the keyboard by pressing down on each of its edges.
+13. Turn the machine lid-side down again and replace the two keyboard screws.
 
 ## Removing the bottom cover:
 
@@ -55,16 +57,18 @@ Removing the cover is required to access the internal components. Prior to remov
 
 ### Steps to remove the bottom cover:
 
-1. Remove the 12 bottom panel screws.
+1. Place the machine lid-side down.
+    - Use a soft surface (such as a towel) to avoid scratches.
+2. Remove the 12 bottom panel screws.
 
 ![Bottom panel screws](./img/bottom-panel-screws.jpg)
 
-2. Follow the steps above to [remove the keyboard](#replacing-the-keyboard).
-3. Remove the three under-keyboard screws holding the bottom panel in place from above, highlighted cyan below.
+3. Follow the steps above to [remove the keyboard](#replacing-the-keyboard).
+4. Remove the three under-keyboard screws holding the bottom panel in place from above, highlighted cyan below.
 
 ![Under-keyboard screws](./img/under-keyboard-screws.jpg)
 
-4. Lift the bottom panel off, starting from the hinges in the back.
+5. Lift the bottom panel off, starting from the hinges in the back.
 
 ## Removing the battery:
 

--- a/src/models/darp7/img/battery-tape.jpg
+++ b/src/models/darp7/img/battery-tape.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9cae96079c670ce61108c5486305f8a5fcc220286bf3cc008a2f687c61f33a10
+size 183835

--- a/src/models/darp7/repairs.md
+++ b/src/models/darp7/repairs.md
@@ -21,14 +21,16 @@ Removing the cover is required to access the internal components. Prior to remov
 
 ### Steps to remove the bottom cover:
 
-1. Remove the 16 bottom panel screws:
+1. Place the machine lid-side down.
+    - Use a soft surface (such as a towel) to avoid scratches.
+2. Remove the 16 bottom panel screws:
     - 12 perimeter screws (thin), highlighted green below.
     - 2 keyboard screws (thicker), highlighted yellow.
     - 2 inner hinge screws (thickest), highlighted red.
 
 ![Bottom panel screws](./img/bottom-screws.jpg)
 
-2. Pull the bottom panel off, starting from the hinges in the back.
+3. Pull the bottom panel off, starting from the hinges in the back.
 
 ## Replacing the RAM:
 
@@ -155,27 +157,29 @@ The keyboard can be replaced using the instructions below.
 
 ### Steps to replace the keyboard:
 
-1. Remove the two keyboard screws (highlighted yellow below).
+1. Place the machine lid-side down.
+    - Use a soft surface (such as a towel) to avoid scratches.
+2. Remove the two keyboard screws (highlighted yellow below).
 
 ![Keyboard screws](./img/keyboard-screws.jpg)
 
-2. Open the lid slightly and place the machine on its side.
-3. Push the screwdriver into the keyboard push point (highlighted cyan above) until the keyboard pops out.
+3. Open the lid slightly and place the machine on its side.
+4. Push the screwdriver into the keyboard push point (highlighted cyan above) until the keyboard pops out.
 
 ![Keyboard push point](./img/keyboard-push-point.jpg)
 
-4. Set the machine back down and raise the keyboard away from the chassis. The larger ribbon cable is for the keyboard, while the smaller ribbon cable is for the keyboard backlight.
+5. Set the machine back down and raise the keyboard away from the chassis. The larger ribbon cable is for the keyboard, while the smaller ribbon cable is for the keyboard backlight.
 
 ![Keyboard ribbons](./img/keyboard-ribbons.jpg)
 
-5. Flip the black latches upwards to free the ribbon cables.
-6. Pull the ribbon cables out of the connectors.
-7. Remove the keyboard and replace it with the new one.
-8. Carefully slide both ribbon cables into their connectors.
-9. Flip the black latches back into place to secure the ribbon cables.
-10. Place the keyboard back into position, starting with the tabs on the bottom edge.
-11. Secure the rest of the keyboard by pressing down on each of its edges.
-12. Turn the machine lid-side down again and replace the two keyboard screws.
+6. Flip the black latches upwards to free the ribbon cables.
+7. Pull the ribbon cables out of the connectors.
+8. Remove the keyboard and replace it with the new one.
+9. Carefully slide both ribbon cables into their connectors.
+10. Flip the black latches back into place to secure the ribbon cables.
+11. Place the keyboard back into position, starting with the tabs on the bottom edge.
+12. Secure the rest of the keyboard by pressing down on each of its edges.
+13. Turn the machine lid-side down again and replace the two keyboard screws.
 
 ## Replacing the battery:
 

--- a/src/models/darp7/repairs.md
+++ b/src/models/darp7/repairs.md
@@ -201,7 +201,7 @@ The battery provides primary power whenever the system is unplugged.
 3. Remove the battery.
     - The battery is secured to foam standoffs with double-sided tape.
     - A flat plastic object (such as a credit card) can be used to separate the tape from the battery.
-    - If any tabs from the tape are visible around the perimiter of the battery, hold them down while inserting the plastic tool so they don't get pushed back under the battery.
+    - If any tabs from the tape are visible around the perimeter of the battery, hold them down while inserting the plastic tool so they don't get pushed back under the battery.
 
 ![Battery tape](./img/battery-tape.jpg)
 

--- a/src/models/darp7/repairs.md
+++ b/src/models/darp7/repairs.md
@@ -198,5 +198,11 @@ The battery provides primary power whenever the system is unplugged.
 
 ![Main battery](./img/battery.jpg)
 
-3. Remove the battery. The battery is secured with tape, which can be pulled off. A flat, blunt plastic tool may be used to help pry the battery off of the chassis.
+3. Remove the battery.
+    - The battery is secured to foam standoffs with double-sided tape.
+    - A flat plastic object (such as a credit card) can be used to separate the tape from the battery.
+    - If any tabs from the tape are visible around the perimiter of the battery, hold them down while inserting the plastic tool so they don't get pushed back under the battery.
+
+![Battery tape](./img/battery-tape.jpg)
+
 4. Put the battery back (or put your new battery in its place) and plug it back into the motherboard.

--- a/src/models/galp4/repairs.md
+++ b/src/models/galp4/repairs.md
@@ -22,29 +22,31 @@ The keyboard can be replaced using the instructions below. Removing the keyboard
 
 ### Steps to replace the keyboard:
 
-1. Remove the two keyboard screws, highlighted red below.
+1. Place the machine lid-side down.
+    - Use a soft surface (such as a towel) to avoid scratches.
+2. Remove the two keyboard screws, highlighted red below.
 
 ![Keyboard screws](./img/keyboard-screws.jpg)
 
-2. Open the lid slightly and place the machine on its side.
-3. Push the screwdriver into the keyboard push point (highlighted blue above) until the keyboard pops out.
+3. Open the lid slightly and place the machine on its side.
+4. Push the screwdriver into the keyboard push point (highlighted blue above) until the keyboard pops out.
 
 ![Keyboard push point](./img/keyboard-push-point.jpg)
 
-4. Set the machine back down and raise the keyboard away from the chassis. The larger ribbon cable is for the keyboard, while the smaller ribbon cable is for the keyboard backlight.
+5. Set the machine back down and raise the keyboard away from the chassis. The larger ribbon cable is for the keyboard, while the smaller ribbon cable is for the keyboard backlight.
 
 ![Keyboard ribbons](./img/keyboard-ribbons.jpg)
 
 _Note: Unplugging the ribbon cables is not required to remove the bottom cover; the keyboard can be flipped over onto the touchpad without unplugging the ribbon cables._
 
-5. Flip the black latches away from the white connectors to free the ribbon cables.
-6. Pull the ribbon cables out of the connectors.
-7. Remove the keyboard and replace it with the new one.
-8. Carefully slide both ribbon cables into their connectors.
-9. Flip the black latches back into place to secure the ribbon cables.
-10. Place the keyboard back into position, starting with the tabs on the bottom edge.
-11. Secure the rest of the keyboard by pressing down on each of its edges.
-12. Turn the machine lid-side down again and replace the two keyboard screws.
+6. Flip the black latches away from the white connectors to free the ribbon cables.
+7. Pull the ribbon cables out of the connectors.
+8. Remove the keyboard and replace it with the new one.
+9. Carefully slide both ribbon cables into their connectors.
+10. Flip the black latches back into place to secure the ribbon cables.
+11. Place the keyboard back into position, starting with the tabs on the bottom edge.
+12. Secure the rest of the keyboard by pressing down on each of its edges.
+13. Turn the machine lid-side down again and replace the two keyboard screws.
 
 ## Removing the bottom cover:
 
@@ -56,16 +58,18 @@ Removing the cover is required to access the internal components. Prior to remov
 
 ### Steps to remove the bottom cover:
 
-1. Remove the 12 bottom panel screws.
+1. Place the machine lid-side down.
+    - Use a soft surface (such as a towel) to avoid scratches.
+2. Remove the 12 bottom panel screws.
 
 ![Bottom panel screws](./img/bottom-panel-screws.jpg)
 
-2. Follow the steps above to [remove the keyboard](#replacing-the-keyboard).
-3. Remove the three under-keyboard screws holding the bottom panel in place from above, highlighted yellow below.
+3. Follow the steps above to [remove the keyboard](#replacing-the-keyboard).
+4. Remove the three under-keyboard screws holding the bottom panel in place from above, highlighted yellow below.
 
 ![Under-keyboard screws](./img/under-keyboard-screws.jpg)
 
-4. Lift the bottom panel off, starting from the hinges in the back.
+5. Lift the bottom panel off, starting from the hinges in the back.
 
 ## Removing the battery:
 

--- a/src/models/galp5/repairs.md
+++ b/src/models/galp5/repairs.md
@@ -21,12 +21,14 @@ Removing the cover is required to access the internal components. Prior to remov
 
 ### Steps to remove the bottom cover:
 
-1. Remove the 14 bottom panel screws.
+1. Place the machine lid-side down.
+    - Use a soft surface (such as a towel) to avoid scratches.
+2. Remove the 14 bottom panel screws.
     - The two hinge corner screws (highlighted yellow below) are slightly thicker than the rest.
 
 ![Bottom panel screws](./img/bottom-panel-screws.jpg)
 
-2. Pull the bottom panel off, starting from the hinges and vents in the back.
+3. Pull the bottom panel off, starting from the hinges and vents in the back.
 
 ## Removing the battery:
 
@@ -183,24 +185,26 @@ The keyboard can be replaced using the instructions below.
 
 ### Steps to replace the keyboard:
 
-1. Remove the two keyboard screws, highlighted cyan below.
+1. Place the machine lid-side down.
+    - Use a soft surface (such as a towel) to avoid scratches.
+2. Remove the two keyboard screws, highlighted cyan below.
 
 ![Keyboard screws](./img/keyboard-screws.jpg)
 
-2. Open the lid slightly and place the machine on its side.
-3. Push the screwdriver into the keyboard push point (highlighted yellow above) until the keyboard pops out.
+3. Open the lid slightly and place the machine on its side.
+4. Push the screwdriver into the keyboard push point (highlighted yellow above) until the keyboard pops out.
 
 ![Keyboard push point](./img/keyboard-push-point.jpg)
 
-4. Set the machine upright and flip the keyboard down onto the touchpad. The larger ribbon cable is for the keyboard, while the smaller ribbon cable is for the keyboard backlight.
+5. Set the machine upright and flip the keyboard down onto the touchpad. The larger ribbon cable is for the keyboard, while the smaller ribbon cable is for the keyboard backlight.
 
 ![Keyboard ribbons](./img/keyboard-ribbons.jpg)
 
-5. Flip the black latches away from the white connectors to free the ribbon cables.
-6. Pull the ribbon cables out of the connectors.
-7. Remove the keyboard and replace it with the new one.
-8. Carefully slide both ribbon cables into their connectors.
-9. Flip the black latches back into place to secure the ribbon cables.
-10. Place the keyboard back into position, starting with the tabs on the bottom edge.
-11. Secure the rest of the keyboard by pressing down on each of its edges.
-12. Turn the machine lid-side down again and replace the two keyboard screws.
+6. Flip the black latches away from the white connectors to free the ribbon cables.
+7. Pull the ribbon cables out of the connectors.
+8. Remove the keyboard and replace it with the new one.
+9. Carefully slide both ribbon cables into their connectors.
+10. Flip the black latches back into place to secure the ribbon cables.
+11. Place the keyboard back into position, starting with the tabs on the bottom edge.
+12. Secure the rest of the keyboard by pressing down on each of its edges.
+13. Turn the machine lid-side down again and replace the two keyboard screws.

--- a/src/models/gaze15/repairs.md
+++ b/src/models/gaze15/repairs.md
@@ -23,7 +23,9 @@ Keyboard replacement is simple and requires only a cross-head screwdriver.
 
 ### Steps to replace the keyboard:
 
-1. Remove the two keyboard screws, indicated by the small keyboard icons (highlighted yellow below).
+1. Place the machine lid-side down.
+    - Use a soft surface (such as a towel) to avoid scratches.
+2. Remove the two keyboard screws, indicated by the small keyboard icons (highlighted yellow below).
 
 **15" version:**
 
@@ -33,23 +35,23 @@ Keyboard replacement is simple and requires only a cross-head screwdriver.
 
 ![Keyboard screws](./img/keyboard-screws-17inch.jpg)
 
-2. Open the Gazelle and place it on its side.
-3. Push the screwdriver into the keyboard push point (highlighted cyan above) until the keyboard pops out.
+3. Open the Gazelle and place it on its side.
+4. Push the screwdriver into the keyboard push point (highlighted cyan above) until the keyboard pops out.
 
 ![Keyboard push point](./img/keyboard-push-point.jpg)
 
-4. Set the machine back down and raise the keyboard away from the chassis. The larger ribbon cable is for the keyboard, while the smaller ribbon cable is for the keyboard backlight.
+5. Set the machine back down and raise the keyboard away from the chassis. The larger ribbon cable is for the keyboard, while the smaller ribbon cable is for the keyboard backlight.
 
 ![Keyboard ribbons](./img/keyboard-ribbons.jpg)
 
-5. Flip the black latches upwards to free the ribbon cables.
-6. Pull the ribbon cables out of the connectors.
-7. Remove the keyboard and replace it with the new one.
-8. Carefully slide both ribbon cables into their connectors.
-9. Flip the black latches back into place to secure the ribbon cables.
-10. Place the keyboard back into position, starting with the tabs on the bottom edge.
-11. Secure the rest of the keyboard by pressing down on each of its edges.
-12. Turn the machine lid-side down again and replace the two keyboard screws.
+6. Flip the black latches upwards to free the ribbon cables.
+7. Pull the ribbon cables out of the connectors.
+8. Remove the keyboard and replace it with the new one.
+9. Carefully slide both ribbon cables into their connectors.
+10. Flip the black latches back into place to secure the ribbon cables.
+11. Place the keyboard back into position, starting with the tabs on the bottom edge.
+12. Secure the rest of the keyboard by pressing down on each of its edges.
+13. Turn the machine lid-side down again and replace the two keyboard screws.
 
 ## Removing the bottom cover:
 
@@ -62,7 +64,8 @@ Removing the cover is required to access the internal components. Prior to remov
 
 ### Steps to remove the bottom cover:
 
-1. Place the Gazelle lid-side down.
+1. Place the machine lid-side down.
+    - Use a soft surface (such as a towel) to avoid scratches.
 2. Remove the external battery.
 3. Remove the bottom panel screws.
 
@@ -199,9 +202,11 @@ The battery provides primary power whenever the system is unplugged.
 
 ### Steps to replace the external battery:
 
-1. Slide the locks that hold the battery to their unlocked positions. (One lock will click into place, while the other is on a spring.)
-2. Hold back the spring-loaded lock while removing the battery.
-3. Replace the battery/insert the new battery, then slide the clicking lock to its locked position.
+1. Place the machine lid-side down.
+    - Use a soft surface (such as a towel) to avoid scratches.
+2. Slide the locks that hold the battery to their unlocked positions. (One lock will click into place, while the other is on a spring.)
+3. Hold back the spring-loaded lock while removing the battery.
+4. Replace the battery/insert the new battery, then slide the clicking lock to its locked position.
 
 ## Replacing the wireless card:
 

--- a/src/models/lemp10/img/battery-tape.jpg
+++ b/src/models/lemp10/img/battery-tape.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:08806f240b266b4a6b6ae212744c45a0591949bb25525595e13e52279e36b85c
+size 146823

--- a/src/models/lemp10/repairs.md
+++ b/src/models/lemp10/repairs.md
@@ -188,7 +188,7 @@ The battery provides primary power whenever the system is unplugged.
 3. Remove the battery.
     - The battery is secured to foam standoffs with double-sided tape.
     - A flat plastic object (such as a credit card) can be used to separate the tape from the battery.
-    - If any tabs from the tape are visible around the perimiter of the battery, hold them down while inserting the plastic tool so they don't get pushed back under the battery.
+    - If any tabs from the tape are visible around the perimeter of the battery, hold them down while inserting the plastic tool so they don't get pushed back under the battery.
 
 ![Battery tape](./img/battery-tape.jpg)
 

--- a/src/models/lemp10/repairs.md
+++ b/src/models/lemp10/repairs.md
@@ -185,5 +185,11 @@ The battery provides primary power whenever the system is unplugged.
 
 ![Main battery](./img/battery.jpg)
 
-3. Remove the battery. The battery is secured with tape, which can be pulled off. The tabs around the battery will also need to be held back for the battery to come out.
+3. Remove the battery.
+    - The battery is secured to foam standoffs with double-sided tape.
+    - A flat plastic object (such as a credit card) can be used to separate the tape from the battery.
+    - If any tabs from the tape are visible around the perimiter of the battery, hold them down while inserting the plastic tool so they don't get pushed back under the battery.
+
+![Battery tape](./img/battery-tape.jpg)
+
 4. Put the battery back (or put your new battery in its place) and plug it back into the motherboard.

--- a/src/models/lemp10/repairs.md
+++ b/src/models/lemp10/repairs.md
@@ -22,7 +22,8 @@ Removing the cover is required to access the internal components. Prior to remov
 
 ### Steps to remove the bottom cover:
 
-1. Place the Lemur Pro lid-side down.
+1. Place the machine lid-side down.
+    - Use a soft surface (such as a towel) to avoid scratches.
 2. Remove the 12 screws from the bottom panel.
 
 ![Bottom case screws](./img/bottom-screws.jpg)

--- a/src/models/lemp9/repairs.md
+++ b/src/models/lemp9/repairs.md
@@ -156,5 +156,8 @@ The battery provides primary power whenever the system is unplugged.
 
 ![Main battery](./img/battery.jpg)
 
-3. Remove the battery. The battery is secured with tape, which can be pulled off. The tabs around the battery will also need to be held back for the battery to come out.
+3. Remove the battery.
+    - The battery is secured to foam standoffs with double-sided tape.
+    - A flat plastic object (such as a credit card) can be used to separate the tape from the battery.
+    - If any tabs from the tape are visible around the perimiter of the battery, hold them down while inserting the plastic tool so they don't get pushed back under the battery.
 4. Put the battery back (or put your new battery in its place) and plug it back into the motherboard.

--- a/src/models/lemp9/repairs.md
+++ b/src/models/lemp9/repairs.md
@@ -21,7 +21,8 @@ Removing the cover is required to access the internal components. Prior to remov
 
 ### Steps to remove the bottom cover:
 
-1. Place the Lemur Pro lid-side down.
+1. Place the machine lid-side down.
+    - Use a soft surface (such as a towel) to avoid scratches.
 2. Remove the 12 screws from the bottom panel.
 
 ![Bottom case screws](./img/bottom-case-screws.jpg)

--- a/src/models/lemp9/repairs.md
+++ b/src/models/lemp9/repairs.md
@@ -159,5 +159,5 @@ The battery provides primary power whenever the system is unplugged.
 3. Remove the battery.
     - The battery is secured to foam standoffs with double-sided tape.
     - A flat plastic object (such as a credit card) can be used to separate the tape from the battery.
-    - If any tabs from the tape are visible around the perimiter of the battery, hold them down while inserting the plastic tool so they don't get pushed back under the battery.
+    - If any tabs from the tape are visible around the perimeter of the battery, hold them down while inserting the plastic tool so they don't get pushed back under the battery.
 4. Put the battery back (or put your new battery in its place) and plug it back into the motherboard.

--- a/src/models/meer5/repairs.md
+++ b/src/models/meer5/repairs.md
@@ -22,11 +22,13 @@ The bottom panel can be removed to access the internal components.
 
 ### Steps to remove the bottom panel:
 
-1. Turn your Meerkat over on its back and completely loosen the four screws in the corners.
+1. Place the machine lid-side down.
+    - Use a soft surface (such as a towel) to avoid scratches.
+1. Completely loosen the four screws in the corners.
 
 ![Bottom panel screws](./img/meer5-bottom-screws.png)
 
-2. The screws are held captive in the bottom panel, so they will not come completely out of the machine, but once they are fully loose, you will be able to grab the screws and gently lift the bottom panel out of the machine. 
+3. The screws are held captive in the bottom panel, so they will not come completely out of the machine, but once they are fully loose, you will be able to grab the screws and gently lift the bottom panel out of the machine. 
 
    If your Meerkat is the Tall variation, use caution when lifting the bottom panel off, as there is a thin cable that attaches to the drive bay in the bottom panel. The cable should be long enough that you can set the bottom panel next to the machine without having to disconnect it at the motherboard, as shown below: 
    

--- a/src/models/oryp6/repairs.md
+++ b/src/models/oryp6/repairs.md
@@ -22,7 +22,8 @@ Keyboard replacement is simple and requires only a cross-head screwdriver.
 
 ### Steps to replace the keyboard:
 
-1. Place the Oryx Pro lid-side down.
+1. Place the machine lid-side down.
+    - Use a soft surface (such as a towel) to avoid scratches.
 2. Remove the 2 keyboard screws, indicated by the small keyboard icons.
 
 ![Keyboard screws](./img/keyboard-screws.jpg)
@@ -61,7 +62,8 @@ Removing the cover is required to access the internal components. Prior to remov
 
 ### Steps to remove the bottom cover:
 
-1. Place the Oryx Pro lid-side down.
+1. Place the machine lid-side down.
+    - Use a soft surface (such as a towel) to avoid scratches.
 2. Remove the 13 bottom panel screws. Note that two of the screws are longer than the rest (highlighted red below.)
 
 ![Bottom panel screws](./img/bottom-panel-screws.jpg)

--- a/src/models/oryp7/repairs.md
+++ b/src/models/oryp7/repairs.md
@@ -21,7 +21,8 @@ Removing the cover is required to access the internal components. Prior to remov
 
 ### Steps to remove the bottom cover:
 
-1. Place the Oryx Pro lid-side down.
+1. Place the machine lid-side down.
+    - Use a soft surface (such as a towel) to avoid scratches.
 2. Remove the 13 bottom panel screws.
     - On the 15" model, the two back corner screws are longer than the rest (highlighted red below.)
     - On the 17" model, all screws are the same length.
@@ -177,24 +178,26 @@ Keyboard replacement is simple and requires only a cross-head screwdriver.
 
 ### Steps to replace the keyboard:
 
-1. Remove the 2 keyboard screws, indicated by the small keyboard icons.
+1. Place the machine lid-side down.
+    - Use a soft surface (such as a towel) to avoid scratches.
+2. Remove the 2 keyboard screws, indicated by the small keyboard icons.
 
 ![Keyboard screws](./img/keyboard-screws.jpg)
 
-2. Open the lid slightly and place the machine on its side.
-3. Push the screwdriver into the keyboard push point (highlighted cyan above) until the keyboard pops out.
+3. Open the lid slightly and place the machine on its side.
+4. Push the screwdriver into the keyboard push point (highlighted cyan above) until the keyboard pops out.
 
 ![Keyboard push point](./img/keyboard-push-point.jpg)
 
-4. Set the machine back down and raise the keyboard away from the chassis. The larger ribbon cable is for the keyboard, while the smaller ribbon cable is for the keyboard backlight.
+5. Set the machine back down and raise the keyboard away from the chassis. The larger ribbon cable is for the keyboard, while the smaller ribbon cable is for the keyboard backlight.
 
 ![Keyboard ribbon connectors](./img/keyboard-ribbons.jpg)
 
-5. Flip the black latches upwards to free the ribbon cables.
-6. Pull the ribbon cables out of the connectors.
-7. Remove the keyboard and replace it with the new one.
-8. Carefully slide both ribbon cables into their connectors.
-9. Flip the black latches back into place to secure the ribbon cables.
-10. Place the keyboard back into position, starting with the tabs on the bottom edge.
-11. Secure the rest of the keyboard by pressing down on each of its edges.
-12. Turn the machine lid-side down again and replace the two keyboard screws.
+6. Flip the black latches upwards to free the ribbon cables.
+7. Pull the ribbon cables out of the connectors.
+8. Remove the keyboard and replace it with the new one.
+9. Carefully slide both ribbon cables into their connectors.
+10. Flip the black latches back into place to secure the ribbon cables.
+11. Place the keyboard back into position, starting with the tabs on the bottom edge.
+12. Secure the rest of the keyboard by pressing down on each of its edges.
+13. Turn the machine lid-side down again and replace the two keyboard screws.

--- a/src/models/pang10/repairs.md
+++ b/src/models/pang10/repairs.md
@@ -21,11 +21,13 @@ Removing the cover is required to access the internal components and to remove t
 
 ### Steps to remove the bottom cover:
 
-1. Remove the 12 bottom panel screws.
+1. Place the machine lid-side down.
+    - Use a soft surface (such as a towel) to avoid scratches.
+2. Remove the 12 bottom panel screws.
 
 ![Bottom panel screws](./img/bottom-panel-screws.jpg)
 
-2. Lift the bottom panel off, starting from the hinges in the back.
+3. Lift the bottom panel off, starting from the hinges in the back.
 
 ## Replacing the keyboard:
 

--- a/src/models/serw12/repairs.md
+++ b/src/models/serw12/repairs.md
@@ -22,7 +22,8 @@ The battery provides primary power whenever the system is unplugged.
 
 ### Steps to remove the battery:
 
-1. Place the Serval WS lid-side down.
+1. Place the machine lid-side down.
+    - Use a soft surface (such as a towel) to avoid scratches.
 2. Unscrew the two battery screws (highlighted yellow below.)
 
 ![Battery screws](./img/battery-screws.jpg)


### PR DESCRIPTION
__Add note about work surface to all applicable models:__

Support requested we add this written detail to address feedback from a customer who scratched up his/her laptop while working on it.

Criteria for adding:
- Any section that requires having the laptop turned upside-down gets the note, except...
- Any section that links to a previous section with the note _before_ requiring to turn the laptop upside-down does not need the note repeated.

__Revise battery removal instructions for lemp9/lemp10/darp7:__

This PR also adds a more detailed and hopefully less confusing description about how to remove the battery from systems where it's held in with adhesive. (There are no tabs holding the battery in place; there are tabs sticking out from the tape underneath the battery.)