### PR TITLE
oryp7: Note that Fn-F2 doesn't apply to OLED models

### DIFF
--- a/src/models/oryp7/external-overview.md
+++ b/src/models/oryp7/external-overview.md
@@ -43,21 +43,21 @@ The Oryx Pro has the following LED indicators:
 
 The Oryx Pro has the following actions available using the Fn and Function keys:
 
-|Key                        |Shortcut|Action                             |
-|---------------------------|--------|-----------------------------------|
-|![Fn-F1](./img/fn-f1.png)  |Fn+F1   |Toggle trackpad                    |
-|![Fn-F2](./img/fn-f2.png)  |Fn+F2   |Toggle built-in LCD                |
-|![Fn-F3](./img/fn-f3.png)  |Fn+F3   |Mute                               |
-|![Fn-F5](./img/fn-f5.png)  |Fn+F5   |Volume down                        |
-|![Fn-F6](./img/fn-f6.png)  |Fn+F6   |Volume up                          |
-|![Fn-F7](./img/fn-f7.png)  |Fn+F7   |Toggle displays                    |
-|![Fn-F8](./img/fn-f8.png)  |Fn+F8   |Screen brightness down             |
-|![Fn-F9](./img/fn-f9.png)  |Fn+F9   |Screen brightness up               |
-|![Fn-F10](./img/fn-f10.png)|Fn+F10  |Toggle webcam                      |
-|![Fn-F11](./img/fn-f11.png)|Fn+F11  |Toggle airplane mode               |
-|![Fn-F12](./img/fn-f12.png)|Fn+F12  |Suspend                            |
-|![Fn-F12](./img/fn-dia.jpg)|Fn+`    |Play/Pause                         |
-|![Fn-*](./img/fn-star.png) |Fn+*    |Toggle keyboard backlight          |
-|/                          |Fn+/    |Cycle keyboard color               |
-|-                          |Fn+-    |Decrease keyboard brightness       |
-|+                          |Fn++    |Increase keyboard brightness       |
+|Key                        |Shortcut|Action                                        |
+|---------------------------|--------|----------------------------------------------|
+|![Fn-F1](./img/fn-f1.png)  |Fn+F1   |Toggle trackpad                               |
+|![Fn-F2](./img/fn-f2.png)  |Fn+F2   |Toggle built-in LCD<br/>(non-OLED models only)|
+|![Fn-F3](./img/fn-f3.png)  |Fn+F3   |Mute                                          |
+|![Fn-F5](./img/fn-f5.png)  |Fn+F5   |Volume down                                   |
+|![Fn-F6](./img/fn-f6.png)  |Fn+F6   |Volume up                                     |
+|![Fn-F7](./img/fn-f7.png)  |Fn+F7   |Toggle displays                               |
+|![Fn-F8](./img/fn-f8.png)  |Fn+F8   |Screen brightness down                        |
+|![Fn-F9](./img/fn-f9.png)  |Fn+F9   |Screen brightness up                          |
+|![Fn-F10](./img/fn-f10.png)|Fn+F10  |Toggle webcam                                 |
+|![Fn-F11](./img/fn-f11.png)|Fn+F11  |Toggle airplane mode                          |
+|![Fn-F12](./img/fn-f12.png)|Fn+F12  |Suspend                                       |
+|![Fn-F12](./img/fn-dia.jpg)|Fn+`    |Play/Pause                                    |
+|![Fn-*](./img/fn-star.png) |Fn+*    |Toggle keyboard backlight                     |
+|/                          |Fn+/    |Cycle keyboard color                          |
+|-                          |Fn+-    |Decrease keyboard brightness                  |
+|+                          |Fn++    |Increase keyboard brightness                  |


### PR DESCRIPTION
Super-Esc can be used instead (to lock and turn off the screen), but I'm not sure if that fits in this section since it's not a firmware/Fn shortcut.