### PR TITLE
pang10: Add HDMI version

### DIFF
--- a/src/models/pang10/README.md
+++ b/src/models/pang10/README.md
@@ -21,7 +21,7 @@ The System76 Pangolin is a laptop with the following specifications:
 - GPU
     - AMD Radeon Vega 7
     - eDP 15.6" 1920x1080 LCD
-    - HDMI out
+    - HDMI 1.4b out
 - Memory
     - Up to 64 (2x32GB) dual-channel DDR4 SO-DIMMs @ 3200 MHz
 - Networking


### PR DESCRIPTION
Upstream hardware supplier stated 1.4b is the version, and our testing confirmed that 2.0 features are not available.