### PR TITLE
lemp10: Highlight webcam connector within internal overview

### DIFF
--- a/src/models/lemp10/img/components-highlighted.jpg
+++ b/src/models/lemp10/img/components-highlighted.jpg
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b5b2a4856aff5c2d091a18b0dc908c01d5b7c43567608be0801cda9fbaa2034b
-size 420170
+oid sha256:aab1283215293f44979942741c59798aeaf83c9a5fd5ea7aab9fbb4c4bb920da
+size 416478

--- a/src/models/lemp10/internal-overview.md
+++ b/src/models/lemp10/internal-overview.md
@@ -10,6 +10,7 @@ Components can be replaced using the instructions under [Parts & Repairs](./repa
 - RAM is highlighted in cyan
 - Wireless card is highlighted in green
 - LCD cable connector is highlighted in yellow
+- Webcam/microphone connector is highlighted in maroon
 - Touchpad connector is highlighted in orange
 - Keyboard connector (main) is highlighted in olive
 - Keyboard backlight connector is highlighted in white


### PR DESCRIPTION
Confirmed via manual testing that this is the CCD (webcam/microphone) connector.