### PR TITLE
removed the phillip driver needed for external battery removal

### DIFF
--- a/src/models/gaze15/repairs.md
+++ b/src/models/gaze15/repairs.md
@@ -196,7 +196,7 @@ The CMOS battery supplies power to the Gazelle's CMOS chip. Changes you make to 
 
 The battery provides primary power whenever the system is unplugged.
 
-**Tools required:** None
+**Tools required:** None  
 **Time estimate:** 1 minute  
 **Difficulty:** Easy <span style="color:green;">●</span>  
 

--- a/src/models/gaze15/repairs.md
+++ b/src/models/gaze15/repairs.md
@@ -196,7 +196,7 @@ The CMOS battery supplies power to the Gazelle's CMOS chip. Changes you make to 
 
 The battery provides primary power whenever the system is unplugged.
 
-**Tools required:** Cross-head (Phillips) screwdriver  
+**Tools required:** None
 **Time estimate:** 1 minute  
 **Difficulty:** Easy <span style="color:green;">●</span>  
 


### PR DESCRIPTION
A customer pointed out that the external battery is not needed for removal of the external battery so this is to update that. 