### PR TITLE
Add meer5 graphics info

### DIFF
--- a/src/models/meer5/README.md
+++ b/src/models/meer5/README.md
@@ -12,6 +12,11 @@ The System76 Meerkat is a desktop with the following specifications:
     - [i3-10110U](https://ark.intel.com/content/www/us/en/ark/products/196451/intel-core-i3-10110u-processor-4m-cache-up-to-4-10-ghz.html)
     - [i5-10210U](https://ark.intel.com/content/www/us/en/ark/products/195436/intel-core-i5-10210u-processor-6m-cache-up-to-4-20-ghz.html)
     - [i7-10710U](https://ark.intel.com/content/www/us/en/ark/products/196448/intel-core-i7-10710u-processor-12m-cache-up-to-4-70-ghz.html)
+- Graphics
+    - GPU: Intel UHD Graphics
+    - Video output:
+        - 1x HDMI 2.0b
+        - 1x DisplayPort 1.2 over USB-C
 - Memory
     - Up to 64GB (2x32GB) Dual Channel  DDR4 SODIMMs @ 2666 MHz
 - Networking

--- a/src/models/oryp7/README.md
+++ b/src/models/oryp7/README.md
@@ -30,7 +30,10 @@ The System76 Oryx Pro is a laptop with the following specifications:
         - 15.6" 3840x2160@60Hz OLED
         - 17.3" 1920x1080@144Hz LCD
         - 17.3" 3840x2160@60Hz LCD
-    - HDMI 2.1, Mini DisplayPort 1.4, and DisplayPort 1.4 over USB-C
+    - External video output:
+        - 1x HDMI 2.1
+        - 1x Mini DisplayPort 1.4
+        - 1x DisplayPort 1.4 over USB-C
 - Memory
     - Up to 64GB (2x32GB) dual-channel DDR4 SO-DIMMs @ 2933 MHz
 - Networking


### PR DESCRIPTION
This adds a graphics section to the meer5 tech specs.

With oryp7, I called this section "Graphics" instead of "GPU" to enable better organization of the GPU options, built-in display options, and video output ports as sub-categories. The meer5 section follows this new formatting.