### PR TITLE
Add LCD panel model numbers

### DIFF
--- a/src/models/addw1/README.md
+++ b/src/models/addw1/README.md
@@ -22,9 +22,9 @@ The System76 Adder WS is a laptop with the following specifications:
     - eDP display: 15.6" 3840x2160@60Hz OLED
         - LCD panel: Samsung ATNA56WR06 (or equivalent)
     - External video output:
-        - 1 x HDMI (w/HDCP)
-        - 1 x Mini DisplayPort 1.3
-        - 1 x DisplayPort 1.3 over USB 3.1 Type C
+        - 1x HDMI (w/HDCP)
+        - 1x Mini DisplayPort 1.3
+        - 1x DisplayPort 1.3 over USB 3.1 Type C
 - Memory
     - Up to 64GB dual-channel DDR4 @ 2666 MHz, or
     - Up to 32GB dual-channel DDR4 @ 3000 MHz

--- a/src/models/addw1/README.md
+++ b/src/models/addw1/README.md
@@ -20,7 +20,7 @@ The System76 Adder WS is a laptop with the following specifications:
 - Graphics
     - GPU: NVIDIA GeForce RTX 2070
     - eDP display: 15.6" 3840x2160@60Hz OLED
-        - LCD panel: Samsung ATNA56WR06 (or equivalent)
+        - OLED panel: Samsung ATNA56WR06 (or equivalent)
     - External video output:
         - 1x HDMI (w/HDCP)
         - 1x Mini DisplayPort 1.3

--- a/src/models/addw1/README.md
+++ b/src/models/addw1/README.md
@@ -17,12 +17,14 @@ The System76 Adder WS is a laptop with the following specifications:
     - MX25L12873F flash chip running System76 Firmware (non-open)
 - EC
     - ITE IT8587E running non-open firmware
-- GPU
-    - NVIDIA GeForce RTX 2070
-    - eDP 15.6-inch 3840x2160 OLED
-    - 1 x HDMI (w/HDCP) output
-    - 1 x Mini DisplayPort (1.3) output
-    - 1 x DisplayPort (1.3) over USB 3.1 Type C output
+- Graphics
+    - GPU: NVIDIA GeForce RTX 2070
+    - eDP display: 15.6" 3840x2160@60Hz OLED
+        - LCD panel: Samsung ATNA56WR06 (or equivalent)
+    - External video output:
+        - 1 x HDMI (w/HDCP)
+        - 1 x Mini DisplayPort 1.3
+        - 1 x DisplayPort 1.3 over USB 3.1 Type C
 - Memory
     - Up to 64GB dual-channel DDR4 @ 2666 MHz, or
     - Up to 32GB dual-channel DDR4 @ 3000 MHz

--- a/src/models/addw2/README.md
+++ b/src/models/addw2/README.md
@@ -15,10 +15,14 @@ The System76 Adder WS is a laptop with the following specifications:
     - MX25L12872F flash chip running [System76 Open Firmware](https://github.com/system76/firmware-open) or non-open firmware
 - EC
     - ITE IT5570E running [System76 EC](https://github.com/system76/ec) or or non-open EC firmware
-- GPU
-    - NVIDIA GeForce RTX 2070 Super
-    - eDP 15.6" 3840x2160 OLED
-    - HDMI, Mini DisplayPort 1.4, and DisplayPort 1.4 over USB-C
+- Graphics
+    - GPU: NVIDIA GeForce RTX 2070 Super
+    - eDP display: 15.6" 3840x2160@60Hz OLED
+        - LCD panel: Samsung ATNA56WR06 (or equivalent)
+    - External video outputs:
+        - 1x HDMI
+        - 1x Mini DisplayPort 1.4
+        - 1x DisplayPort 1.4 over USB-C
 - Memory
     - Up to 64 (2x32GB) dual-channel DDR4 SO-DIMMs @ 3200 MHz
 - Networking

--- a/src/models/addw2/README.md
+++ b/src/models/addw2/README.md
@@ -18,7 +18,7 @@ The System76 Adder WS is a laptop with the following specifications:
 - Graphics
     - GPU: NVIDIA GeForce RTX 2070 Super
     - eDP display: 15.6" 3840x2160@60Hz OLED
-        - LCD panel: Samsung ATNA56WR06 (or equivalent)
+        - OLED panel: Samsung ATNA56WR06 (or equivalent)
     - External video outputs:
         - 1x HDMI
         - 1x Mini DisplayPort 1.4

--- a/src/models/bonw14/README.md
+++ b/src/models/bonw14/README.md
@@ -19,13 +19,20 @@ The System76 Bonobo WS is a laptop with the following specifications:
     - GD25B127D flash chip running [System76 Open Firmware](https://github.com/system76/firmware-open)
 - EC
     - ITE IT5570E running [System76 EC](https://github.com/system76/ec)
-- GPU
-    - NVIDIA GeForce RTX 2080 Super
-        - or NVIDIA GeForce RTX 2070 Super
-        - or NVIDIA GeForce RTX 2060
-    - eDP 17.3" 1920x1080@144Hz LCD
-        - or eDP 17.3" 3840x2160@60Hz LCD
-    - HDMI, 2 x Mini DisplayPort 1.4, and 2 x DisplayPort 1.4 over USB-C
+- Graphics
+    - GPU options:
+        - NVIDIA GeForce RTX 2080 Super
+        - NVIDIA GeForce RTX 2070 Super
+        - NVIDIA GeForce RTX 2060
+    - eDP display options:
+        - 17.3" 1920x1080@144Hz LCD
+            - LCD panel: LG LP173WFG-SPB1 (or equivalent)
+        - 17.3" 3840x2160@60Hz LCD
+            - LCD panel: AUO B173ZAN03.0 (or equivalent)
+    - External video outputs:
+        - 1x HDMI
+        - 2 x Mini DisplayPort 1.4
+        - 2 x DisplayPort 1.4 over USB-C
 - Memory
     - Up to 128GB (4x32GB) quad-channel DDR4 SO-DIMMs @ 3200 MHz
 - Networking

--- a/src/models/darp6/README.md
+++ b/src/models/darp6/README.md
@@ -16,10 +16,14 @@ The System76 Darter Pro is a laptop with the following specifications:
     - GD25B127D flash chip running [System76 Open Firmware](https://github.com/system76/firmware-open)
 - EC
     - ITE IT8587E running [System76 EC](https://github.com/system76/ec) or non-open EC firmware
-- GPU
-    - Intel UHD Graphics 620
-    - eDP 15.6" 1920x1080 LCD
-    - HDMI, Mini DisplayPort 1.2, and DisplayPort 1.3 over USB-C
+- Graphics
+    - GPU: Intel UHD Graphics 620
+    - eDP display: 15.6" 1920x1080@60Hz LCD
+        - LCD panel: LG LP156WFC-SPD3 (or equivalent)
+    - External video outputs:
+        - 1x HDMI
+        - 1x Mini DisplayPort 1.2
+        - 1x DisplayPort 1.3 over USB-C
 - Memory
     - Up to 64GB (2x32GB) dual-channel DDR4 SO-DIMMs @ 2666 MHz
 - Networking

--- a/src/models/darp7/README.md
+++ b/src/models/darp7/README.md
@@ -16,10 +16,16 @@ The System76 Darter Pro is a laptop with the following specifications:
     - GD25B127D flash chip running [System76 Open Firmware](https://github.com/system76/firmware-open)
 - EC
     - ITE IT5570E running [System76 EC](https://github.com/system76/ec) or non-open EC firmware
-- GPU
-    - Intel Iris Xe Graphics
-    - eDP 15.6" 1920x1080 LCD
-    - HDMI, DisplayPort 1.4 over USB-C
+- Graphics
+    - GPU: Intel Iris Xe Graphics
+    - eDP display: 15.6" 1920x1080@60Hz LCD
+        - LCD panel options:
+            - AUO B156HAN02.5
+            - BOE NV156FHM-N4H
+            - or other equivalent
+    - External video outputs:
+        - 1x HDMI
+        - 1x DisplayPort 1.4 over USB-C
 - Memory
     - Up to 64GB (2x32GB) dual-channel DDR4 SO-DIMMs @ 3200 MHz
 - Networking

--- a/src/models/galp4/README.md
+++ b/src/models/galp4/README.md
@@ -16,10 +16,14 @@ The System76 Galago Pro is a laptop with the following specifications:
     - GD25B127D flash chip running [System76 Open Firmware](https://github.com/system76/firmware-open)
 - EC
     - ITE IT8587E running [System76 EC](https://github.com/system76/ec) or non-open EC firmware
-- GPU
-    - Intel UHD Graphics 620
-    - eDP 14.1" 1920x1080 LCD
-    - HDMI, Mini DisplayPort 1.2, and DisplayPort over USB-C
+- Graphics
+    - GPU: Intel UHD Graphics 620
+    - eDP display: 14.1" 1920x1080@60Hz LCD
+        - LCD panel: Innolux N140HCA-EAC (or equivalent)
+    - External video outputs:
+        - 1x HDMI
+        - 1x Mini DisplayPort 1.2
+        - 1x DisplayPort over USB-C
 - Memory
     - Up to 64 (2x32GB) dual-channel DDR4 SO-DIMMs @ 2666 MHz
 - Networking

--- a/src/models/galp5/README.md
+++ b/src/models/galp5/README.md
@@ -16,11 +16,16 @@ The System76 Galago Pro is a laptop with the following specifications:
     - GD25B127D flash chip running [System76 Open Firmware](https://github.com/system76/firmware-open)
 - EC
     - ITE IT5570E running [System76 EC](https://github.com/system76/ec)
-- GPU
-    - Intel Iris Xe Graphics
-    - (Optional) NVIDIA GeForce GTX 1650
-    - eDP 14.1" 1920x1080 LCD
-    - HDMI and DisplayPort 1.4 over USB-C
+- Graohics
+    - GPU options:
+        - Intel Iris Xe Graphics (Integrated graphics model)
+        - NVIDIA GeForce GTX 1650 (Switchable graphics model)
+        - NVIDIA GeForce GTX 1650 Ti (Switchable graphics model)
+    - eDP display: 14.1" 1920x1080@60Hz LCD
+        - LCD panel: BOE NV140FHM-N62 (or equivalent)
+    - External video outputs:
+        - 1x HDMI
+        - 1x DisplayPort 1.4 over USB-C
 - Memory
     - Up to 64 (2x32GB) dual-channel DDR4 SO-DIMMs @ 3200 MHz
 - Networking

--- a/src/models/galp5/README.md
+++ b/src/models/galp5/README.md
@@ -16,7 +16,7 @@ The System76 Galago Pro is a laptop with the following specifications:
     - GD25B127D flash chip running [System76 Open Firmware](https://github.com/system76/firmware-open)
 - EC
     - ITE IT5570E running [System76 EC](https://github.com/system76/ec)
-- Graohics
+- Graphics
     - GPU options:
         - Intel Iris Xe Graphics (Integrated graphics model)
         - NVIDIA GeForce GTX 1650 (Switchable graphics model)

--- a/src/models/gaze15/README.md
+++ b/src/models/gaze15/README.md
@@ -15,14 +15,20 @@ The System76 Gazelle is a laptop with the following specifications:
     - GD25B127D flash chip running System76 Firmware (non-open)
 - EC
     - ITE IT5570E running non-open firmware
-- GPU
-    - NVIDIA GeForce GTX 1650
-        - 1 x HDMI, 1 x Mini DisplayPort 1.4
-    - or NVIDIA GeForce GTX 1650 Ti
-        - 1 x HDMI, 1 x Mini DisplayPort 1.4
-    - or NVIDIA GeForce GTX 1660 Ti
-        - 1 x HDMI, 1 x Mini DisplayPort 1.4, 1 x DisplayPort 1.4 over USB 3.1 Type-C
-    - eDP 15.6" or 17.3" 1920x1080@120Hz LCD
+- Graphics
+    - GPU options:
+        - NVIDIA GeForce GTX 1650
+        - NVIDIA GeForce GTX 1650 Ti
+        - NVIDIA GeForce GTX 1660 Ti
+    - eDP display options:
+        - 15.6" 1920x1080@120Hz LCD
+            - LCD panel: Panda LM156LF2F (or equivalent)
+        - 17.3" 1920x1080@120Hz LCD
+            - LCD panel: AUO B173HAN04.7 (or equivalent)
+    - External video outputs:
+        - 1x HDMI
+        - 1x Mini DisplayPort 1.4
+        - (1660 Ti model only) 1x DisplayPort 1.4 over USB 3.1 Type-C
 - Memory
     - Up to 64GB dual-channel DDR4 @ 2666 MHz, or
     - Up to 32GB dual-channel DDR4 @ 2933 MHz

--- a/src/models/lemp10/README.md
+++ b/src/models/lemp10/README.md
@@ -16,11 +16,14 @@ The System76 Lemur Pro is a laptop with the following specifications:
     - GD25B127D flash chip running [System76 Open Firmware](https://github.com/system76/firmware-open)
 - EC
     - ITE IT5570E running [System76 EC](https://github.com/system76/ec)
-- GPU
-    - Intel Iris Xe Graphics
-    - GOP driver is recommended, VBT is provided
-    - eDP 14.1" 1920x1080 LCD
-    - HDMI and DisplayPort 1.4 over USB-C
+- Graphics
+    - GPU: Intel Iris Xe Graphics
+        - GOP driver is recommended, VBT is provided
+    - eDP display: 14.0" 1920x1080@60Hz LCD
+        - LCD panel: Innolux N140HCE-EN2 (or equivalent)
+    - External video outputs:
+        - 1x HDMI
+        - 1x DisplayPort 1.4 over USB-C
 - Memory
     - Channel 0: 8-GB on-board DDR4 ([Samsung K4AAG165WA-BCWE](https://www.samsung.com/semiconductor/dram/ddr4/K4AAG165WA-BCWE/) x 8)
     - Channel 1: 8-GB/16-GB/32-GB DDR4 SO-DIMM @ 3200 MHz

--- a/src/models/lemp9/README.md
+++ b/src/models/lemp9/README.md
@@ -21,12 +21,14 @@ The System76 Lemur Pro is a laptop with the following specifications:
     - Charger, using AC adapter or USB-C PD
     - Suspend/resume
     - Touchpad
-- GPU
-    - Intel UHD Graphics 620
-    - GOP driver is recommended, VBT is provided
-    - eDP 14-inch 1920x1080 LCD
-    - HDMI video
-    - USB-C DisplayPort video
+- Graphics
+    - GPU: Intel UHD Graphics 620
+        - GOP driver is recommended, VBT is provided
+    - eDP display: 14" 1920x1080@60Hz LCD
+        - LCD panel: Innolux N140HCA-EAC (or equivalent)
+    - External video outputs:
+        - 1x HDMI
+        - 1x DisplayPort over USB-C
 - Memory
     - Channel 0: 8-GB on-board DDR4 [Samsung K4AAG165WA-BCTD](https://www.samsung.com/semiconductor/dram/ddr4/K4AAG165WA-BCTD/)
     - Channel 1: 8-GB/16-GB/32-GB DDR4 SO-DIMM

--- a/src/models/lemp9/README.md
+++ b/src/models/lemp9/README.md
@@ -24,7 +24,7 @@ The System76 Lemur Pro is a laptop with the following specifications:
 - Graphics
     - GPU: Intel UHD Graphics 620
         - GOP driver is recommended, VBT is provided
-    - eDP display: 14" 1920x1080@60Hz LCD
+    - eDP display: 14.0" 1920x1080@60Hz LCD
         - LCD panel: Innolux N140HCA-EAC (or equivalent)
     - External video outputs:
         - 1x HDMI

--- a/src/models/oryp6/README.md
+++ b/src/models/oryp6/README.md
@@ -17,12 +17,20 @@ The System76 Oryx Pro is a laptop with the following specifications:
     - MX25L12872F flash chip running [System76 Open Firmware](https://github.com/system76/firmware-open)
 - EC
     - ITE IT5570E running [System76 EC](https://github.com/system76/ec)
-- GPU
-    - NVIDIA GeForce RTX 2080 Super (Max-Q)
-    - or NVIDIA GeForce RTX 2070 (Max-Q)
-    - or NVIDIA GeForce RTX 2060
-    - eDP 15.6" or 17.3" 1920x1080@144Hz LCD
-    - HDMI, Mini DisplayPort 1.4, and DisplayPort over USB-C
+- Graphics
+    - GPU options:
+        - NVIDIA GeForce RTX 2080 Super (Max-Q)
+        - NVIDIA GeForce RTX 2070 (Max-Q)
+        - NVIDIA GeForce RTX 2060
+    - eDP display options:
+        - 15.6" 1920x1080@144Hz LCD
+            - LCD panel: Panda LM156LF1F (or equivalent)
+        - 17.3" 1920x1080@144Hz LCD
+            - LCD panel: LG LP173WFG-SPB1 (or equivalent)
+    - External video outputs:
+        - 1x HDMI
+        - 1x Mini DisplayPort 1.4
+        - 1x DisplayPort over USB-C
 - Memory
     - Up to 64GB (2x32GB) dual-channel DDR4 SO-DIMMs @ 3200 MHz
 - Networking

--- a/src/models/oryp7/README.md
+++ b/src/models/oryp7/README.md
@@ -27,9 +27,11 @@ The System76 Oryx Pro is a laptop with the following specifications:
             - TGP: 80W
     - eDP display options:
         - 15.6" 1920x1080@144Hz LCD
+            - LCD panel: LG LP156WFG-SPB3 (or equivalent)
         - 15.6" 3840x2160@60Hz OLED
+            - LCD panel: Samsung ATNA56WR06 (or equivalent)
         - 17.3" 1920x1080@144Hz LCD
-        - 17.3" 3840x2160@60Hz LCD
+            - LCD panel: LG LP173WFG-SPB1 (or equivalent)
     - External video output:
         - 1x HDMI 2.1
         - 1x Mini DisplayPort 1.4

--- a/src/models/oryp7/README.md
+++ b/src/models/oryp7/README.md
@@ -29,7 +29,7 @@ The System76 Oryx Pro is a laptop with the following specifications:
         - 15.6" 1920x1080@144Hz LCD
             - LCD panel: LG LP156WFG-SPB3 (or equivalent)
         - 15.6" 3840x2160@60Hz OLED
-            - LCD panel: Samsung ATNA56WR06 (or equivalent)
+            - OLED panel: Samsung ATNA56WR06 (or equivalent)
         - 17.3" 1920x1080@144Hz LCD
             - LCD panel: LG LP173WFG-SPB1 (or equivalent)
     - External video output:

--- a/src/models/pang10/README.md
+++ b/src/models/pang10/README.md
@@ -22,7 +22,7 @@ The System76 Pangolin is a laptop with the following specifications:
     - GPU: AMD Radeon Vega 7
     - eDP display: 15.6" 1920x1080@60Hz LCD
         - LCD panel: LG LP156WFC-SPD1 (or equivalent)
-    - External video output: 1x HDMI 1.4b out
+    - External video output: 1x HDMI 1.4b
 - Memory
     - Up to 64 (2x32GB) dual-channel DDR4 SO-DIMMs @ 3200 MHz
 - Networking

--- a/src/models/pang10/README.md
+++ b/src/models/pang10/README.md
@@ -18,10 +18,11 @@ The System76 Pangolin is a laptop with the following specifications:
     - W74M12JWSSIQ flash chip running non-open System76 firmware
 - EC
     - ITE IT5570 running non-open EC firmware
-- GPU
-    - AMD Radeon Vega 7
-    - eDP 15.6" 1920x1080 LCD
-    - HDMI 1.4b out
+- Graphics
+    - GPU: AMD Radeon Vega 7
+    - eDP display: 15.6" 1920x1080@60Hz LCD
+        - LCD panel: LG LP156WFC-SPD1 (or equivalent)
+    - External video output: 1x HDMI 1.4b out
 - Memory
     - Up to 64 (2x32GB) dual-channel DDR4 SO-DIMMs @ 3200 MHz
 - Networking

--- a/src/models/serw12/README.md
+++ b/src/models/serw12/README.md
@@ -19,11 +19,19 @@ The System76 Serval WS is a laptop with the following specifications:
     - MX25U12872F flash chip running System76 Firmware (non-open)
 - EC
     - ITE IT5570E
-- GPU
-    - NVIDIA GeForce RTX 2070
-    - or NVIDIA GeForce GTX 1660 Ti
-    - eDP 15.6" 1920x1080@120Hz LCD
-    - HDMI, Mini DisplayPort 1.4, and DisplayPort 1.4 over USB-C
+- Graphics
+    - GPU options:
+        - NVIDIA GeForce RTX 2070
+        - NVIDIA GeForce GTX 1660 Ti
+    - eDP display: 15.6" 1920x1080@144Hz LCD
+        - LCD panel options:
+            - Panda LM156LF-2F01
+            - LG P156WFG-SPB2
+            - or other equivalent
+    - External video outputs:
+        - 1x HDMI
+        - 1x Mini DisplayPort 1.4
+        - 1x DisplayPort 1.4 over USB-C
 - Memory
     - Up to 64GB (2x32GB) dual-channel DDR4 SO-DIMMs @ 3200 MHz
 - Networking


### PR DESCRIPTION
Closes #6.

This adds at least one compatible LCD panel model number for each laptop (I listed all numbers we're aware of, so some models have more than one option listed.) Every model number is accompanied by `or equivalent`, so we should be safe in case our supply chain causes any of these to change, which does happen from time to time.

This also reorganizes all `Graphics` sections to use the newer format, and makes the following small corrections:
- lemp9 and lemp10 were both 14.0", not 14.1".
- serw12 was/is 144Hz (we originally marketed 120Hz, but both panels say 144Hz.)
- Added 1650 Ti to galp5.