### PR TITLE
gaze16: Correct BIOS flash chip

### DIFF
--- a/src/models/gaze16/internal-overview.md
+++ b/src/models/gaze16/internal-overview.md
@@ -12,7 +12,7 @@
 - M.2 SSDs are highlighted in yellow
 - 2.5" storage drive is highlighted in purple
 - CMOS battery connector is highlighted in cyan
-- BIOS flash chip (U66) is highlighted in black
+- BIOS flash chip (U51 on 3050, U52 on 3060) is highlighted in black
 - Speaker connectors are highlighted in light green
 - Touchpad connector is highlighted in white
 


### PR DESCRIPTION
- Flash chip on 3050 is U51
  - U52 is for a WSON8 socket for the chip
- Flash chip on 3060 is U52