### PR TITLE
Link Typo Fix

### DIFF
--- a/src/models/thelio-major-intel-and-amd/repairs.md
+++ b/src/models/thelio-major-intel-and-amd/repairs.md
@@ -15,7 +15,7 @@
 - [Replacing the Top Case](#replacing-the-top-case)
 ### Power Button (Remove or Replace)
 - [Removing the Power Button](#removing-the-power-button)
-- [Replacing the Power Button](#replacing-the-power-buttom)
+- [Replacing the Power Button](#replacing-the-power-button)
 
 <!--### IO Board (Remove or Replace)
 - [Removing the IO Board](#removing-the-io-board)


### PR DESCRIPTION
There was an "m" that should have been an "n" in the link for the "Replacing the Power Button" section in the ToC for the Thelio Major