### PR TITLE
add lemp9 HDMI spec

### DIFF
--- a/src/models/lemp9/README.md
+++ b/src/models/lemp9/README.md
@@ -27,7 +27,7 @@ The System76 Lemur Pro is a laptop with the following specifications:
     - eDP display: 14.0" 1920x1080@60Hz LCD
         - LCD panel: Innolux N140HCA-EAC (or equivalent)
     - External video outputs:
-        - 1x HDMI
+        - 1x HDMI 1.4a
         - 1x DisplayPort over USB-C
 - Memory
     - Channel 0: 8-GB on-board DDR4 [Samsung K4AAG165WA-BCTD](https://www.samsung.com/semiconductor/dram/ddr4/K4AAG165WA-BCTD/)


### PR DESCRIPTION
This PR does the following:

- Adds the HDMI spec for the lemp9.