### PR TITLE
Add missing 2.5 drive section 

### DIFF
--- a/src/models/addw1/img/25-bracket-screw.jpg
+++ b/src/models/addw1/img/25-bracket-screw.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dbfd9878149cf405de5d2640e0d90dbfb874ab605200172ed97be7312d931386
+size 252196

--- a/src/models/addw1/img/25-drive-removal.jpg
+++ b/src/models/addw1/img/25-drive-removal.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fb050b8faa4a63a880795b376b702446b84720b6d6f74d7aa5f9e1c8dc14b8b5
+size 96267

--- a/src/models/addw1/img/25-side-screw.jpg
+++ b/src/models/addw1/img/25-side-screw.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:160cb8f70843f96de38c290e4cc771ac36f92466bde79f5a166923f985ff3bec
+size 43592

--- a/src/models/addw1/repairs.md
+++ b/src/models/addw1/repairs.md
@@ -134,7 +134,7 @@ This model supports one 2.5" (7mm height) SATA III SSD or hard drive.
 **Time estimate:** 12 minutes  
 **Difficulty:** Easy <span style="color:green;">●</span>  
 
-1. Follow the steps above to [remove the battery](#removing-the-battery), [remove the keyboard](#removing-the-keyboard), and [remove the bottom cover](#removing-the-bottom-cover).
+1. Follow the steps to [remove the battery](#replacing-the-external-battery), [remove the keyboard](#replacing-the-keyboard), and [remove the bottom cover](#removing-the-bottom-cover).
 2. Unscrew the single screw holding the 2.5" drive bracket into the case.
 
 ![2.5" drive bracket screw](./img/25-bracket-screw.jpg)

--- a/src/models/addw1/repairs.md
+++ b/src/models/addw1/repairs.md
@@ -6,6 +6,7 @@ Many components on your Adder WS can be upgraded or replaced as necessary. Follo
 - [Removing the bottom cover](#removing-the-bottom-cover)
 - [Replacing the RAM](#replacing-the-ram)
 - [Replacing an M.2/NVMe SSD](#replacing-an-m2nvme-ssd)
+- [Replacing a 2.5" storage drive](#replacing-a-25-storage-drive)
 - [Replacing the fans/heatsink/thermal paste](#replacing-the-cooling-system)
 - [Replacing the CMOS battery](#replacing-the-cmos-battery)
 - [Replacing the external battery](#replacing-the-external-battery)
@@ -124,6 +125,31 @@ M.2 SSDs offer, at minimum, SATA III speeds and performance in a package about t
 4. Remove the existing M.2 drive by pulling it out of the slot.
 5. Insert the new M.2 drive into the slot and hold it in place.
 6. Replace the retainer screw.
+
+## Replacing a 2.5" storage drive:
+
+This model supports one 2.5" (7mm height) SATA III SSD or hard drive.
+
+**Tools required:** Cross-head (Phillips) screwdriver  
+**Time estimate:** 12 minutes  
+**Difficulty:** Easy <span style="color:green;">●</span>  
+
+1. Follow the steps above to [remove the battery](#removing-the-battery), [remove the keyboard](#removing-the-keyboard), and [remove the bottom cover](#removing-the-bottom-cover).
+2. Unscrew the single screw holding the 2.5" drive bracket into the case.
+
+![2.5" drive bracket screw](./img/25-bracket-screw.jpg)
+
+3. Slightly lift the loose end of the 2.5" drive and slide it out of the SATA port.
+
+![2.5" drive removal](./img/25-drive-removal.jpg)
+
+4. Unscrew the two screws holding the 2.5" drive into the drive bracket (one on either side.)
+
+![2.5" drive side screw](./img/25-side-screw.jpg)
+
+5. Insert the new 2.5" drive into the drive bracket and replace the two side screws.
+6. Plug the 2.5" drive into the SATA port and set the drive into the case.
+7. Screw the drive bracket back into the case.
 
 ## Replacing the cooling system:
 


### PR DESCRIPTION
This PR does the following:

- Copies the 2.5" section from the addw2 to the addw1
- Copies the photos from the addw2 to the addw1
- Fixes this [issue](https://github.com/system76/tech-docs/issues/117)

![ksnip_20220401-083114](https://user-images.githubusercontent.com/4884946/161284301-e8160833-6fba-4922-ae68-ff307f2a3d32.png)

