### PR TITLE
CI: Update mdBook from 0.3.5 to 0.4.18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Build
         env:
-          MDBOOK_VERSION: 0.3.5
+          MDBOOK_VERSION: 0.4.18
         run: |
-          cargo install mdbook --no-default-features --features output,search --vers ${MDBOOK_VERSION}
+          cargo install mdbook --no-default-features --features search --vers ${MDBOOK_VERSION}
           mdbook build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,9 +20,9 @@ jobs:
 
       - name: Build
         env:
-          MDBOOK_VERSION: 0.3.5
+          MDBOOK_VERSION: 0.4.18
         run: |
-          cargo install mdbook --no-default-features --features output,search --vers ${MDBOOK_VERSION}
+          cargo install mdbook --no-default-features --features search --vers ${MDBOOK_VERSION}
           mdbook build
 
       - name: Setup Hosting


### PR DESCRIPTION
0.3.5 was released 2019-11-11.
0.4.18 was released 2022-04-15.

See mdBook [`CHANGELOG.md`](https://github.com/rust-lang/mdBook/blob/master/CHANGELOG.md) for details.