### PR TITLE
Correct plug type for _kudu6_ AC adapter (C13, not C5)

### DIFF
--- a/src/models/kudu6/README.md
+++ b/src/models/kudu6/README.md
@@ -37,7 +37,7 @@ The System76 Kudu is a laptop with the following specifications:
 - Power
     - 230W (19.5V, 11.8A) AC adapter
         - Included AC adapter: Chicony A17-230P1A
-        - Included AC adapter uses standard PC C13 power cord
+        - Included AC adapter uses C13 power cord
         - Barrel size: 5.5mm (outer), 2.5mm (inner)
     - 48.96Wh 4-cell Lithium-Ion battery
         - Model number: NH50BAT-4

--- a/src/models/kudu6/README.md
+++ b/src/models/kudu6/README.md
@@ -37,7 +37,7 @@ The System76 Kudu is a laptop with the following specifications:
 - Power
     - 230W (19.5V, 11.8A) AC adapter
         - Included AC adapter: Chicony A17-230P1A
-        - Included AC adapter uses C13 power cord
+        - Included AC adapter uses a C13 power cord
         - Barrel size: 5.5mm (outer), 2.5mm (inner)
     - 48.96Wh 4-cell Lithium-Ion battery
         - Model number: NH50BAT-4

--- a/src/models/kudu6/README.md
+++ b/src/models/kudu6/README.md
@@ -37,7 +37,7 @@ The System76 Kudu is a laptop with the following specifications:
 - Power
     - 230W (19.5V, 11.8A) AC adapter
         - Included AC adapter: Chicony A17-230P1A
-        - Included AC adapter uses C13 ("kettle cord") power cord
+        - Included AC adapter uses standard PC C13 power cord
         - Barrel size: 5.5mm (outer), 2.5mm (inner)
     - 48.96Wh 4-cell Lithium-Ion battery
         - Model number: NH50BAT-4

--- a/src/models/kudu6/README.md
+++ b/src/models/kudu6/README.md
@@ -37,7 +37,7 @@ The System76 Kudu is a laptop with the following specifications:
 - Power
     - 230W (19.5V, 11.8A) AC adapter
         - Included AC adapter: Chicony A17-230P1A
-        - Included AC adapter uses C5 (Cloverleaf) power cord
+        - Included AC adapter uses C13 ("kettle cord") power cord
         - Barrel size: 5.5mm (outer), 2.5mm (inner)
     - 48.96Wh 4-cell Lithium-Ion battery
         - Model number: NH50BAT-4


### PR DESCRIPTION
Small update to correct the power cord plug type for the _kudu6_ AC adapter. The docs say "C5 (Cloverleaf)" but the Chicony A17-230P1A actually a C13 plug, like a desktop PC power supply. Levi confirmed this with a QA unit.