### PR TITLE
Make power cord specs more consistent

### DIFF
--- a/src/models/addw1/README.md
+++ b/src/models/addw1/README.md
@@ -29,8 +29,8 @@ The System76 Adder WS is a laptop with the following specifications:
     - Up to 64GB dual-channel DDR4 @ 2666 MHz, or
     - Up to 32GB dual-channel DDR4 @ 3000 MHz
 - Power
-    - 230W (19.5V, 11.8A) AC adapter
-        - Included AC adapter: Chicony A17-230P1A
-            - AC power cord type: IEC C13
+    - 230W (19.5V, 11.8A) DC-in port
         - Barrel size: 5.5mm (outer), 2.5mm (inner)
+    - Included AC adapter: Chicony A17-230P1A
+        - AC power cord type: IEC C13
     - Removable 62Wh 6-cell battery

--- a/src/models/addw1/README.md
+++ b/src/models/addw1/README.md
@@ -30,7 +30,7 @@ The System76 Adder WS is a laptop with the following specifications:
     - Up to 32GB dual-channel DDR4 @ 3000 MHz
 - Power
     - 230W (19.5V, 11.8A) AC adapter
-        - Included AC adapter is a Chicony A17-230P1A
-        - Included AC adapter uses C5 (Cloverleaf) power cord
+        - Included AC adapter: Chicony A17-230P1A
+            - AC power cord type: IEC C13
         - Barrel size: 5.5mm (outer), 2.5mm (inner)
     - Removable 62Wh 6-cell battery

--- a/src/models/addw2/README.md
+++ b/src/models/addw2/README.md
@@ -31,8 +31,8 @@ The System76 Adder WS is a laptop with the following specifications:
         - Intel Wi-Fi 6 AX200/AX201
 - Power
     - 230W (19.5V, 11.8A) AC adapter
-        - Included AC adapter is a Chicony A17-230P1A
-        - Included AC adapter uses C5 (Cloverleaf) power cord
+        - Included AC adapter: Chicony A17-230P1A
+            - AC power cord type: IEC C13
         - Barrel size: 5.5mm (outer), 2.5mm (inner)
     - 62Wh 6-cell Lithium-Ion battery
 - Sound

--- a/src/models/addw2/README.md
+++ b/src/models/addw2/README.md
@@ -30,10 +30,10 @@ The System76 Adder WS is a laptop with the following specifications:
     - M.2 PCIe/CNVi WiFi/Bluetooth
         - Intel Wi-Fi 6 AX200/AX201
 - Power
-    - 230W (19.5V, 11.8A) AC adapter
-        - Included AC adapter: Chicony A17-230P1A
-            - AC power cord type: IEC C13
+    - 230W (19.5V, 11.8A) DC-in port
         - Barrel size: 5.5mm (outer), 2.5mm (inner)
+    - Included AC adapter: Chicony A17-230P1A
+        - AC power cord type: IEC C13
     - 62Wh 6-cell Lithium-Ion battery
 - Sound
     - Internal speakers & microphone

--- a/src/models/bonw14/README.md
+++ b/src/models/bonw14/README.md
@@ -40,10 +40,10 @@ The System76 Bonobo WS is a laptop with the following specifications:
     - M.2 PCIe/CNVi WiFi/Bluetooth
         - Intel Wi-Fi 6 AX200/AX201
 - Power
-    - 2 x 280W (20V, 14A) AC adapter
-        - Included AC adapters: Chicony A18-280P1A
-            - AC power cord type: IEC C13 (one per AC adapter)
+    - 2x 280W (20V, 14A) DC-in ports
         - DC-in ports accept rectangular (not barrel) connectors
+    - Included AC adapters: 2x Chicony A18-280P1A
+        - AC power cord type: IEC C13 (one per AC adapter)
     - 97Wh 8-cell Lithium-Ion battery
 - Sound
     - Internal speakers (stereo + subwoofer) & microphone

--- a/src/models/bonw14/README.md
+++ b/src/models/bonw14/README.md
@@ -41,8 +41,8 @@ The System76 Bonobo WS is a laptop with the following specifications:
         - Intel Wi-Fi 6 AX200/AX201
 - Power
     - 2 x 280W (20V, 14A) AC adapter
-        - Included AC adapters are Chicony A18-280P1A
-        - Included AC adapters use C13 power cord
+        - Included AC adapters: Chicony A18-280P1A
+            - AC power cord type: IEC C13 (one per AC adapter)
         - DC-in ports accept rectangular (not barrel) connectors
     - 97Wh 8-cell Lithium-Ion battery
 - Sound

--- a/src/models/darp6/README.md
+++ b/src/models/darp6/README.md
@@ -33,8 +33,8 @@ The System76 Darter Pro is a laptop with the following specifications:
         - or Intel Wireless-AC 9560
 - Power
     - 65W (19V, 3.42A) AC adapter
-        - Included AC adapter is a Chicony A12-065N2A
-        - Included AC adapter uses C5 (Cloverleaf) power cord
+        - Included AC adapter: Chicony A12-065N2A
+            - AC power cord type: IEC C5
         - Barrel size: 5.5mm (outer), 2.5mm (inner)
     - 54.5Wh 4-cell Lithium-Ion battery
 - Sound

--- a/src/models/darp6/README.md
+++ b/src/models/darp6/README.md
@@ -32,10 +32,10 @@ The System76 Darter Pro is a laptop with the following specifications:
         - Intel Wi-Fi 6 AX200/AX201
         - or Intel Wireless-AC 9560
 - Power
-    - 65W (19V, 3.42A) AC adapter
-        - Included AC adapter: Chicony A12-065N2A
-            - AC power cord type: IEC C5
+    - 65W (19V, 3.42A) DC-in port
         - Barrel size: 5.5mm (outer), 2.5mm (inner)
+    - Included AC adapter: Chicony A12-065N2A
+        - AC power cord type: IEC C5
     - 54.5Wh 4-cell Lithium-Ion battery
 - Sound
     - Internal speakers & microphone

--- a/src/models/darp7/README.md
+++ b/src/models/darp7/README.md
@@ -35,7 +35,7 @@ The System76 Darter Pro is a laptop with the following specifications:
 - Power
     - 65W (19V, 3.42A) AC adapter
         - Included AC adapter: Chicony A18-065N3A
-        - Included AC adapter uses C5 (Cloverleaf) power cord
+            - AC power cord type: IEC C5
         - Barrel size: 5.5mm (outer), 2.5mm (inner)
     - USB-C charging compatible with 65W+ charger
     - 73Wh 4-cell Lithium-ion battery

--- a/src/models/darp7/README.md
+++ b/src/models/darp7/README.md
@@ -33,10 +33,10 @@ The System76 Darter Pro is a laptop with the following specifications:
     - M.2 PCIe/CNVi WiFi/Bluetooth
         - Intel Wi-Fi 6 AX200/AX201
 - Power
-    - 65W (19V, 3.42A) AC adapter
-        - Included AC adapter: Chicony A18-065N3A
-            - AC power cord type: IEC C5
+    - 65W (19V, 3.42A) DC-in port
         - Barrel size: 5.5mm (outer), 2.5mm (inner)
+    - Included AC adapter: Chicony A18-065N3A
+        - AC power cord type: IEC C5
     - USB-C charging compatible with 65W+ charger
     - 73Wh 4-cell Lithium-ion battery
 - Sound

--- a/src/models/galp4/README.md
+++ b/src/models/galp4/README.md
@@ -33,8 +33,8 @@ The System76 Galago Pro is a laptop with the following specifications:
         - or Intel Wireless-AC 9560
 - Power
     - 40W (19V, 2.1A) AC adapter
-        - Included AC adapter is a Chicony A13-040A3A
-        - Included AC adapter uses C5 (Cloverleaf) power cord
+        - Included AC adapter: Chicony A13-040A3A
+            - AC power cord type: IEC C5
         - Barrel size: 4mm (outer), 1.7mm (inner)
     - 35.3Wh 3-cell Lithium-Ion battery
 - Sound

--- a/src/models/galp4/README.md
+++ b/src/models/galp4/README.md
@@ -32,10 +32,10 @@ The System76 Galago Pro is a laptop with the following specifications:
         - Intel Wi-Fi 6 AX200/AX201
         - or Intel Wireless-AC 9560
 - Power
-    - 40W (19V, 2.1A) AC adapter
-        - Included AC adapter: Chicony A13-040A3A
-            - AC power cord type: IEC C5
+    - 40W (19V, 2.1A) DC-in port
         - Barrel size: 4mm (outer), 1.7mm (inner)
+    - Included AC adapter: Chicony A13-040A3A
+        - AC power cord type: IEC C5
     - 35.3Wh 3-cell Lithium-Ion battery
 - Sound
     - Internal speakers & microphone

--- a/src/models/galp5/README.md
+++ b/src/models/galp5/README.md
@@ -35,22 +35,22 @@ The System76 Galago Pro is a laptop with the following specifications:
         - Intel Wi-Fi 6 AX200/AX201
 - Power
     - Intel-only model:
-        - 65W (19V, 3.42A) AC adapter
-            - Included AC adapter: Chicony A18-065N3A
-                - AC power cord type: IEC C5
+        - 65W (19V, 3.42A) DC-in port
             - Barrel size: 5.5mm (outer), 2.5mm (inner)
+        - Included AC adapter: Chicony A18-065N3A
+            - AC power cord type: IEC C5
         - USB-C charging compatible with 65W+ charger
     - NVIDIA 1650/1650 Ti + Intel model:
-        - 90W (19V, 4.74A) AC adapter
-            - Included AC adapter: Chicony A16-090P1A
-                - AC power cord type: IEC C5
+        - 90W (19V, 4.74A) DC-in port
             - Barrel size: 5.5mm (outer), 2.5mm (inner)
+        - Included AC adapter: Chicony A16-090P1A
+            - AC power cord type: IEC C5
         - USB-C charging compatible with 90W+ charger
     - NVIDIA 3050 + Intel model:
-        - 120W (19V, 6.15A) AC adapter
-            - Included AC adapter: LiteOn PA-1121-26
-                - AC power cord type: IEC C5
+        - 120W (19V, 6.15A) DC-in port
             - Barrel size: 5.5mm (outer), 2.5mm (inner)
+        - Included AC adapter: LiteOn PA-1121-26
+            - AC power cord type: IEC C5
         - USB-C charging compatible with 120W+ charger
     - 49Wh 4-cell Lithium-Ion battery
 - Sound

--- a/src/models/galp5/README.md
+++ b/src/models/galp5/README.md
@@ -36,20 +36,20 @@ The System76 Galago Pro is a laptop with the following specifications:
 - Power
     - Intel-only model:
         - 65W (19V, 3.42A) AC adapter
-            - Included AC adapter is a Chicony A18-065N3A
-            - Included AC adapter uses C5 (Cloverleaf) power cord
+            - Included AC adapter: Chicony A18-065N3A
+                - AC power cord type: IEC C5
             - Barrel size: 5.5mm (outer), 2.5mm (inner)
         - USB-C charging compatible with 65W+ charger
     - NVIDIA 1650/1650 Ti + Intel model:
         - 90W (19V, 4.74A) AC adapter
-            - Included AC adapter is a Chicony A16-090P1A
-            - Included AC adapter uses C5 (Cloverleaf) power cord
+            - Included AC adapter: Chicony A16-090P1A
+                - AC power cord type: IEC C5
             - Barrel size: 5.5mm (outer), 2.5mm (inner)
         - USB-C charging compatible with 90W+ charger
     - NVIDIA 3050 + Intel model:
         - 120W (19V, 6.15A) AC adapter
-            - Included AC adapter is a LiteOn PA-1121-26
-            - Included AC adapter uses C5 (Cloverleaf) power cord
+            - Included AC adapter: LiteOn PA-1121-26
+                - AC power cord type: IEC C5
             - Barrel size: 5.5mm (outer), 2.5mm (inner)
         - USB-C charging compatible with 120W+ charger
     - 49Wh 4-cell Lithium-Ion battery

--- a/src/models/gaze15/README.md
+++ b/src/models/gaze15/README.md
@@ -40,13 +40,13 @@ The System76 Gazelle is a laptop with the following specifications:
 - Power
     - GTX 1650 and 1650 Ti models:
         - 120W AC adapter
-            - Included AC adapter is a Chicony A17-120P1A
-            - Included AC adapter uses C5 (Cloverleaf) power cord
+            - Included AC adapter: Chicony A17-120P1A
+                - AC power cord type: IEC C5
             - Barrel size: 5.5mm (outer), 2.5mm (inner)
     - GTX 1660 Ti model:
         - 180W AC adapter
-            - Included AC adapter is a Chicony A17-180P4A
-            - Included AC adapter uses C5 (Cloverleaf) power cord
+            - Included AC adapter: Chicony A17-180P4A
+                - AC power cord type: IEC C5
             - Barrel size: 5.5mm (outer), 2.5mm (innter)
     - 48.96Wh battery
 - Sound

--- a/src/models/gaze15/README.md
+++ b/src/models/gaze15/README.md
@@ -39,15 +39,15 @@ The System76 Gazelle is a laptop with the following specifications:
         - Intel Wi-Fi 6 AX200/AX201
 - Power
     - GTX 1650 and 1650 Ti models:
-        - 120W AC adapter
-            - Included AC adapter: Chicony A17-120P1A
-                - AC power cord type: IEC C5
+        - 120W DC-in port
             - Barrel size: 5.5mm (outer), 2.5mm (inner)
+        - Included AC adapter: Chicony A17-120P1A
+            - AC power cord type: IEC C5
     - GTX 1660 Ti model:
-        - 180W AC adapter
-            - Included AC adapter: Chicony A17-180P4A
-                - AC power cord type: IEC C5
+        - 180W DC-in port
             - Barrel size: 5.5mm (outer), 2.5mm (innter)
+        - Included AC adapter: Chicony A17-180P4A
+            - AC power cord type: IEC C5
     - 48.96Wh battery
 - Sound
     - Internal speaker & microphone

--- a/src/models/gaze16/README.md
+++ b/src/models/gaze16/README.md
@@ -46,15 +46,15 @@ The System76 Gazelle is a laptop with the following specifications:
         - Intel Wi-Fi 6 AX200/AX201
 - Power
     - RTX 3050 and 3050 Ti models:
-        - 150W AC adapter
-            - Included AC adapter: Chicony A17-150P2A
-                - AC power cord type: IEC C5
+        - 150W DC-in port
             - Barrel size: 5.5mm (outer), 2.5mm (inner)
+        - Included AC adapter: Chicony A17-150P2A
+            - AC power cord type: IEC C5
     - RTX 3060 model:
-        - 180W AC adapter
-            - Included AC adapter: Chicony A17-180P4A
-                - AC power cord type: IEC C5
+        - 180W DC-in port
             - Barrel size: 5.5mm (outer), 2.5mm (innter)
+        - Included AC adapter: Chicony A17-180P4A
+            - AC power cord type: IEC C5
     - 48.96Wh 4-cell battery (model number NH50BAT-4)
 - Sound
     - Internal speakers & microphone

--- a/src/models/gaze16/README.md
+++ b/src/models/gaze16/README.md
@@ -47,13 +47,13 @@ The System76 Gazelle is a laptop with the following specifications:
 - Power
     - RTX 3050 and 3050 Ti models:
         - 150W AC adapter
-            - Included AC adapter is a Chicony A17-150P2A
-            - Included AC adapter uses C5 (Cloverleaf) power cord
+            - Included AC adapter: Chicony A17-150P2A
+                - AC power cord type: IEC C5
             - Barrel size: 5.5mm (outer), 2.5mm (inner)
     - RTX 3060 model:
         - 180W AC adapter
-            - Included AC adapter is a Chicony A17-180P4A
-            - Included AC adapter uses C5 (Cloverleaf) power cord
+            - Included AC adapter: Chicony A17-180P4A
+                - AC power cord type: IEC C5
             - Barrel size: 5.5mm (outer), 2.5mm (innter)
     - 48.96Wh 4-cell battery (model number NH50BAT-4)
 - Sound

--- a/src/models/kudu6/README.md
+++ b/src/models/kudu6/README.md
@@ -35,10 +35,10 @@ The System76 Kudu is a laptop with the following specifications:
     - M.2 PCIe/CNVi WiFi/Bluetooth
         - Intel Wi-Fi 6 AX200/AX201
 - Power
-    - 230W (19.5V, 11.8A) AC adapter
-        - Included AC adapter: Chicony A17-230P1A
-            - AC power cord type: IEC C13
+    - 230W (19.5V, 11.8A) DC-in port
         - Barrel size: 5.5mm (outer), 2.5mm (inner)
+    - Included AC adapter: Chicony A17-230P1A
+        - AC power cord type: IEC C13
     - 48.96Wh 4-cell Lithium-Ion battery
         - Model number: NH50BAT-4
 - Sound

--- a/src/models/kudu6/README.md
+++ b/src/models/kudu6/README.md
@@ -37,7 +37,7 @@ The System76 Kudu is a laptop with the following specifications:
 - Power
     - 230W (19.5V, 11.8A) AC adapter
         - Included AC adapter: Chicony A17-230P1A
-        - Included AC adapter uses a C13 power cord
+            - AC power cord type: IEC C13
         - Barrel size: 5.5mm (outer), 2.5mm (inner)
     - 48.96Wh 4-cell Lithium-Ion battery
         - Model number: NH50BAT-4

--- a/src/models/lemp10/README.md
+++ b/src/models/lemp10/README.md
@@ -33,8 +33,8 @@ The System76 Lemur Pro is a laptop with the following specifications:
         - Intel Wi-Fi 6 AX200/AX201
 - Power
     - 19V, 3.42A (65W) AC adapter
-      - Included AC adapter is an AcBel ADA012
-      - Included AC adapter uses C7 power cord (non-polarized)
+      - Included AC adapter: AcBel ADA012
+          - AC power cord type: IEC C7 (non-polarized)
       - Barrel size: 5.5mm (outer), 2.5mm (inner)
     - USB-C charging compatible with 65W+ charger
     - 73Wh 4-cell Lithium-Ion battery

--- a/src/models/lemp10/README.md
+++ b/src/models/lemp10/README.md
@@ -32,10 +32,10 @@ The System76 Lemur Pro is a laptop with the following specifications:
     - M.2 PCIe/CNVi WiFi/Bluetooth
         - Intel Wi-Fi 6 AX200/AX201
 - Power
-    - 19V, 3.42A (65W) AC adapter
-      - Included AC adapter: AcBel ADA012
-          - AC power cord type: IEC C7 (non-polarized)
-      - Barrel size: 5.5mm (outer), 2.5mm (inner)
+    - 19V, 3.42A (65W) DC-in port
+        - Barrel size: 5.5mm (outer), 2.5mm (inner)
+    - Included AC adapter: AcBel ADA012
+        - AC power cord type: IEC C7 (non-polarized)
     - USB-C charging compatible with 65W+ charger
     - 73Wh 4-cell Lithium-Ion battery
     - [TI BQ24780S Battery Charger](https://www.ti.com/product/BQ24780S)

--- a/src/models/lemp9/README.md
+++ b/src/models/lemp9/README.md
@@ -35,10 +35,10 @@ The System76 Lemur Pro is a laptop with the following specifications:
 - Networking
     - M.2 PCIe/CNVi WiFi/Bluetooth
 - Power
-    - 19V, 3.42A (65W) AC adapter
-      - Included AC adapter: AcBel ADA012
+    - 19V, 3.42A (65W) DC-in port
+        - Barrel size: 5.5mm (outer), 2.5mm (inner)
+    - Included AC adapter: AcBel ADA012
         - AC power cord type: IEC C7 (non-polarized)
-      - Barrel size: 5.5mm (outer), 2.5mm (inner)
     - 73Wh battery
     - [TI BQ24780S Battery Charger](https://www.ti.com/product/BQ24780S)
 - Sound

--- a/src/models/lemp9/README.md
+++ b/src/models/lemp9/README.md
@@ -36,8 +36,8 @@ The System76 Lemur Pro is a laptop with the following specifications:
     - M.2 PCIe/CNVi WiFi/Bluetooth
 - Power
     - 19V, 3.42A (65W) AC adapter
-      - Included AC adapter is an AcBel ADA012
-      - Included AC adapter uses C7 power cord (non-polarized)
+      - Included AC adapter: AcBel ADA012
+        - AC power cord type: IEC C7 (non-polarized)
       - Barrel size: 5.5mm (outer), 2.5mm (inner)
     - 73Wh battery
     - [TI BQ24780S Battery Charger](https://www.ti.com/product/BQ24780S)

--- a/src/models/meer5/README.md
+++ b/src/models/meer5/README.md
@@ -23,14 +23,16 @@ The System76 Meerkat is a desktop with the following specifications:
     - Intel® Ethernet Connection [I219-V](https://ark.intel.com/content/www/us/en/ark/products/82186/intel-ethernet-connection-i219v.html)
     - Intel® Wi-Fi 6 [AX201](https://ark.intel.com/content/www/us/en/ark/products/130293/intel-wi-fi-6-ax201-gig.html) (with Bluetooth 5.2)
 - Power
-    - i3 and i5 models: 90W (19V, 4.74A) power supply
+    - i3 and i5 models:
+        - 90W (19V, 4.74A) DC-in port
+            - Barrel size: 5.5mm (outer), 2.5mm (inner)
         - Included AC adapter*: APD DA-90J19
             - AC power cord type: IEC C5
-        - Barrel size: 5.5mm (outer), 2.5mm (inner)
-    - i7 model: 120W (19V, 6.32A) power supply
+    - i7 model:
+        - 120W (19V, 6.32A) DC-in port
+            - Barrel size: 5.5mm (outer), 2.5mm (inner)
         - Included AC adapter*: FSP FSP120-ABBN3
             - AC power cord type: IEC C5
-        - Barrel size: 5.5mm (outer), 2.5mm (inner)
     - \* Included AC adapter may be a different model with the same specifications.
 - Sound
     - 3.5mm line out/line in combo jack for headsets

--- a/src/models/meer5/README.md
+++ b/src/models/meer5/README.md
@@ -25,11 +25,11 @@ The System76 Meerkat is a desktop with the following specifications:
 - Power
     - i3 and i5 models: 90W (19V, 4.74A) power supply
         - Included AC adapter*: APD DA-90J19
-        - Included AC adapter uses C5 (Cloverleaf) power cord
+            - AC power cord type: IEC C5
         - Barrel size: 5.5mm (outer), 2.5mm (inner)
     - i7 model: 120W (19V, 6.32A) power supply
         - Included AC adapter*: FSP FSP120-ABBN3
-        - Included AC adapter uses C5 (Cloverleaf) power cord
+            - AC power cord type: IEC C5
         - Barrel size: 5.5mm (outer), 2.5mm (inner)
     - \* Included AC adapter may be a different model with the same specifications.
 - Sound

--- a/src/models/meer6/README.md
+++ b/src/models/meer6/README.md
@@ -23,14 +23,16 @@ The System76 Meerkat is a desktop with the following specifications:
     - Intel® Ethernet Controller [i225-LM](https://ark.intel.com/content/www/us/en/ark/products/184675/intel-ethernet-controller-i225-lm.html)
     - Intel® Wi-Fi 6 [AX201](https://ark.intel.com/content/www/us/en/ark/products/130293/intel-wi-fi-6-ax201-gig.html) (with Bluetooth 5.2)
 - Power
-    - i3 model: 90W (19V, 4.74A) power supply
+    - i3 model:
+        - 90W (19V, 4.74A) DC-in port
+            - Barrel size: 5.5mm (outer), 2.5mm (inner)
         - Included AC adapter*: APD DA-90J19
             - AC power cord type: IEC C5
-        - Barrel size: 5.5mm (outer), 2.5mm (inner)
-    - i5 and i7 models: 120W (19V, 6.32A) power supply
+    - i5 and i7 models:
+        - 120W (19V, 6.32A) DC-in port
+            - Barrel size: 5.5mm (outer), 2.5mm (inner)
         - Included AC adapter*: FSP FSP120-ABBN3
             - AC power cord type: IEC C5
-        - Barrel size: 5.5mm (outer), 2.5mm (inner)
     - \* Included AC adapter may be a different model with the same specifications.
 - Sound
     - 7.1-channel digital audio output over HDMI and USB-C

--- a/src/models/meer6/README.md
+++ b/src/models/meer6/README.md
@@ -25,11 +25,11 @@ The System76 Meerkat is a desktop with the following specifications:
 - Power
     - i3 model: 90W (19V, 4.74A) power supply
         - Included AC adapter*: APD DA-90J19
-        - Included AC adapter uses C5 (Cloverleaf) power cord
+            - AC power cord type: IEC C5
         - Barrel size: 5.5mm (outer), 2.5mm (inner)
     - i5 and i7 models: 120W (19V, 6.32A) power supply
         - Included AC adapter*: FSP FSP120-ABBN3
-        - Included AC adapter uses C5 (Cloverleaf) power cord
+            - AC power cord type: IEC C5
         - Barrel size: 5.5mm (outer), 2.5mm (inner)
     - \* Included AC adapter may be a different model with the same specifications.
 - Sound

--- a/src/models/oryp6/README.md
+++ b/src/models/oryp6/README.md
@@ -38,10 +38,10 @@ The System76 Oryx Pro is a laptop with the following specifications:
     - M.2 PCIe/CNVi WiFi/Bluetooth
         - Intel Wi-Fi 6 AX200/AX201
 - Power
-    - 180W (19.5V, 9.23A) AC adapter
-        - Included AC adapter: Chicony A17-180P4A
-            - AC power cord type: IEC C5
+    - 180W (19.5V, 9.23A) DC-in port
         - Barrel size: 5.5mm (outer), 2.5mm (inner)
+    - Included AC adapter: Chicony A17-180P4A
+        - AC power cord type: IEC C5
     - 73Wh 3-cell battery
 - Sound
     - Internal speakers & microphone

--- a/src/models/oryp6/README.md
+++ b/src/models/oryp6/README.md
@@ -39,8 +39,8 @@ The System76 Oryx Pro is a laptop with the following specifications:
         - Intel Wi-Fi 6 AX200/AX201
 - Power
     - 180W (19.5V, 9.23A) AC adapter
-        - Included AC adapter is a Chicony A17-180P4A
-        - Included AC adapter uses C5 (Cloverleaf) power cord
+        - Included AC adapter: Chicony A17-180P4A
+            - AC power cord type: IEC C5
         - Barrel size: 5.5mm (outer), 2.5mm (inner)
     - 73Wh 3-cell battery
 - Sound

--- a/src/models/oryp7/README.md
+++ b/src/models/oryp7/README.md
@@ -43,10 +43,10 @@ The System76 Oryx Pro is a laptop with the following specifications:
     - M.2 PCIe/CNVi WiFi/Bluetooth
         - Intel Wi-Fi 6 AX200/AX201
 - Power
-    - 180W (19.5V, 9.23A) AC adapter
-        - Included AC adapter: Chicony A17-180P4A
-            - AC power cord type: IEC C5
+    - 180W (19.5V, 9.23A) DC-in port
         - Barrel size: 5.5mm (outer), 2.5mm (inner)
+    - Included AC adapter: Chicony A17-180P4A
+        - AC power cord type: IEC C5
     - 73Wh 3-cell battery
 - Sound
     - Internal speakers & microphone

--- a/src/models/oryp7/README.md
+++ b/src/models/oryp7/README.md
@@ -45,7 +45,7 @@ The System76 Oryx Pro is a laptop with the following specifications:
 - Power
     - 180W (19.5V, 9.23A) AC adapter
         - Included AC adapter: Chicony A17-180P4A
-        - Included AC adapter uses C5 (Cloverleaf) power cord
+            - AC power cord type: IEC C5
         - Barrel size: 5.5mm (outer), 2.5mm (inner)
     - 73Wh 3-cell battery
 - Sound

--- a/src/models/oryp8/README.md
+++ b/src/models/oryp8/README.md
@@ -41,7 +41,7 @@ The System76 Oryx Pro is a laptop with the following specifications:
 - Power
     - 180W (19.5V, 9.23A) AC adapter
         - Included AC adapter: Lite-On PA-1181-16
-        - Included AC adapter uses C5 (Cloverleaf) power cord
+            - AC power cord type: IEC C5
         - Barrel size: 5.5mm (outer), 2.5mm (inner)
     - 73Wh 3-cell battery
 - Sound

--- a/src/models/oryp8/README.md
+++ b/src/models/oryp8/README.md
@@ -39,10 +39,10 @@ The System76 Oryx Pro is a laptop with the following specifications:
     - M.2 PCIe/CNVi WiFi/Bluetooth
         - Intel Wi-Fi 6 AX200/AX201
 - Power
-    - 180W (19.5V, 9.23A) AC adapter
-        - Included AC adapter: Lite-On PA-1181-16
-            - AC power cord type: IEC C5
+    - 180W (19.5V, 9.23A) DC-in port
         - Barrel size: 5.5mm (outer), 2.5mm (inner)
+    - Included AC adapter: Lite-On PA-1181-16
+        - AC power cord type: IEC C5
     - 73Wh 3-cell battery
 - Sound
     - Internal speakers & microphone

--- a/src/models/pang10/README.md
+++ b/src/models/pang10/README.md
@@ -30,10 +30,10 @@ The System76 Pangolin is a laptop with the following specifications:
     - M.2 PCIe/CNVi WiFi/Bluetooth
         - [Intel Wi-Fi 6 AX200NGW](https://ark.intel.com/content/www/us/en/ark/products/189347/intel-wi-fi-6-ax200-gig.html)
 - Power
-    - 65W (19V, 3.42A) AC adapter
-        - Included AC adapter: Chicony A18-065N3A
-            - AC power cord type: IEC C5
+    - 65W (19V, 3.42A) DC-in port
         - Barrel size: 5.5mm (outer), 2.5mm (inner)
+    - Included AC adapter: Chicony A18-065N3A
+        - AC power cord type: IEC C5
     - 49Wh 4-cell Lithium-Ion battery (model number NL40BAT-4)
 - Sound
     - Internal speakers & microphone

--- a/src/models/pang10/README.md
+++ b/src/models/pang10/README.md
@@ -31,8 +31,8 @@ The System76 Pangolin is a laptop with the following specifications:
         - [Intel Wi-Fi 6 AX200NGW](https://ark.intel.com/content/www/us/en/ark/products/189347/intel-wi-fi-6-ax200-gig.html)
 - Power
     - 65W (19V, 3.42A) AC adapter
-        - Included AC adapter is a Chicony A18-065N3A
-        - Included AC adapter uses C5 (Cloverleaf) power cord
+        - Included AC adapter: Chicony A18-065N3A
+            - AC power cord type: IEC C5
         - Barrel size: 5.5mm (outer), 2.5mm (inner)
     - 49Wh 4-cell Lithium-Ion battery (model number NL40BAT-4)
 - Sound

--- a/src/models/pang11/README.md
+++ b/src/models/pang11/README.md
@@ -29,8 +29,8 @@ The System76 Pangolin is a laptop with the following specifications:
         - [Intel Wi-Fi 6 AX200NGW](https://ark.intel.com/content/www/us/en/ark/products/189347/intel-wi-fi-6-ax200-gig.html)
 - Power
     - 65W (19V, 3.42A) AC adapter
-        - Included AC adapter is a Chicony A18-065N3A
-        - Included AC adapter uses C5 (Cloverleaf) power cord
+        - Included AC adapter: Chicony A18-065N3A
+            - AC power cord type: IEC C5
         - Barrel size: 5.5mm (outer), 2.5mm (inner)
     - 49Wh 4-cell Lithium-Ion battery (model number NL40BAT-4)
 - Sound

--- a/src/models/pang11/README.md
+++ b/src/models/pang11/README.md
@@ -28,10 +28,10 @@ The System76 Pangolin is a laptop with the following specifications:
     - M.2 PCIe/CNVi WiFi/Bluetooth
         - [Intel Wi-Fi 6 AX200NGW](https://ark.intel.com/content/www/us/en/ark/products/189347/intel-wi-fi-6-ax200-gig.html)
 - Power
-    - 65W (19V, 3.42A) AC adapter
-        - Included AC adapter: Chicony A18-065N3A
-            - AC power cord type: IEC C5
+    - 65W (19V, 3.42A) DC-in port
         - Barrel size: 5.5mm (outer), 2.5mm (inner)
+    - Included AC adapter: Chicony A18-065N3A
+        - AC power cord type: IEC C5
     - 49Wh 4-cell Lithium-Ion battery (model number NL40BAT-4)
 - Sound
     - Internal speakers & microphone

--- a/src/models/serw12/README.md
+++ b/src/models/serw12/README.md
@@ -39,14 +39,16 @@ The System76 Serval WS is a laptop with the following specifications:
     - M.2 PCIe/CNVi WiFi/Bluetooth
         - Intel Wi-Fi 6 AX200/AX201
 - Power
-    - RTX 2070: 230W (19.5V, 11.8A) AC adapter
+    - RTX 2070:
+        - 230W (19.5V, 11.8A) DC-in port
+            - Barrel size: 5.5mm (outer), 2.5mm (inner)
         - Included AC adapter: Chicony A17-230P1A
             - AC power cord type: IEC C13
-        - Barrel size: Barrel size: 5.5mm (outer), 2.5mm (inner)
-    - GTX 1660 Ti: 180W (19.5V, 9.23A) AC adapter
+    - GTX 1660 Ti:
+        - 180W (19.5V, 9.23A) DC-in port
+            - Barrel size: 5.5mm (outer), 2.5mm (inner)
         - Included AC adapter: Chicony A17-180P4A
             - AC power cord type: IEC C5
-        - Barrel size: Barrel size: 5.5mm (outer), 2.5mm (inner)
     - 62Wh 6-cell battery
 - Sound
     - Internal speakers & microphone

--- a/src/models/serw12/README.md
+++ b/src/models/serw12/README.md
@@ -40,12 +40,12 @@ The System76 Serval WS is a laptop with the following specifications:
         - Intel Wi-Fi 6 AX200/AX201
 - Power
     - RTX 2070: 230W (19.5V, 11.8A) AC adapter
-        - Included AC adapter is a Chicony A17-230P1A
-        - Included AC adapter uses C5 (Cloverleaf) power cord
+        - Included AC adapter: Chicony A17-230P1A
+            - AC power cord type: IEC C13
         - Barrel size: Barrel size: 5.5mm (outer), 2.5mm (inner)
     - GTX 1660 Ti: 180W (19.5V, 9.23A) AC adapter
-        - Included AC adapter is a Chicony A17-180P4A
-        - Included AC adapter uses C5 (Cloverleaf) power cord
+        - Included AC adapter: Chicony A17-180P4A
+            - AC power cord type: IEC C5
         - Barrel size: Barrel size: 5.5mm (outer), 2.5mm (inner)
     - 62Wh 6-cell battery
 - Sound

--- a/src/models/thelio-major-intel-and-amd/README.md
+++ b/src/models/thelio-major-intel-and-amd/README.md
@@ -63,7 +63,7 @@ Up to 46 TB, M.2 NVMe and 2.5″ SATA drives
 **Power Supply** 	
 
 - 1000W 80+ Certified (90% or greater power efficiency)
-- C13 power cable
+- C13 power cord
 
 **Dimensions** 	
 

--- a/src/models/thelio-massive-b1.2/README.md
+++ b/src/models/thelio-massive-b1.2/README.md
@@ -52,7 +52,7 @@ The System76 Thelio Massive is a desktop with the following specifications:
     - Optional Gigabyte Wireless-AC (a/b/g/n/ac) with Bluetooth
 - Power
     - EVGA SuperNOVA 1600W G2 80+ Gold Certified PSU
-    - C19 power cable
+    - C19 power cord
 - Sound
     - 3.5mm line out, line in, microphone jacks
     - Optical S/PDIF out

--- a/src/models/thelio-mega-r1.0/README.md
+++ b/src/models/thelio-mega-r1.0/README.md
@@ -44,7 +44,7 @@ The System76 Thelio Mega is a desktop with the following specifications:
     - Wi-Fi 6 (Intel AX200)
 - Power
     - EVGA SuperNOVA 1600W T2 80+ Titanium Certified PSU
-    - C19 power cable
+    - C19 power cord
 - Sound
     - 3.5mm line out, line in, microphone jacks
     - Optical S/PDIF out

--- a/src/models/thelio-mira-b1.0/README.md
+++ b/src/models/thelio-mira-b1.0/README.md
@@ -60,7 +60,7 @@ The System76 Thelio Mira is a desktop with the following specifications:
     - 1x 2.5-Gigabit Ethernet (Intel I225-V)
     - Wi-Fi 6 (Intel AX200)
 - Power
-    - C13 power cable
+    - C13 power cord
     - 650W minimum PSU
         - Dual-GPU configurations require 750W or 1000W, depending on GPU power requirements
     - Tested with the following PSU models (may ship with other tested models):

--- a/src/models/thelio-mira-r1.0/README.md
+++ b/src/models/thelio-mira-r1.0/README.md
@@ -63,7 +63,7 @@ The System76 Thelio Mira is a desktop with the following specifications:
         - [EVGA 220-B5-0650 (650W)](https://www.evga.com/products/product.aspx?pn=220-B5-0650-V1)
         - [EVGA 220-G5-0750 (750W)](https://www.evga.com/products/product.aspx?pn=220-G5-0750-X1)
         - [EVGA 220-G5-1000 (1000W)](https://www.evga.com/products/product.aspx?pn=220-G5-1000-X1)
-    - C13 power cable
+    - C13 power cord
 - Sound
     - 3.5mm line out, line in, microphone jacks
     - Optical S/PDIF out


### PR DESCRIPTION
Also fix power cord type on addw1, addw2, and 2070 serw12 (C5 -> C13)

Also change "cable" to "cord" on desktops