### PR TITLE
Add basic server pages

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,3 +8,7 @@
 *.PNG filter=lfs diff=lfs merge=lfs -text
 *.webp filter=lfs diff=lfs merge=lfs -text
 *.WEBP filter=lfs diff=lfs merge=lfs -text
+*.pdf filter=lfs diff=lfs merge=lfs -text
+*.PDF filter=lfs diff=lfs merge=lfs -text
+*.avif filter=lfs diff=lfs merge=lfs -text
+*.AVIF filter=lfs diff=lfs merge=lfs -text

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -14,6 +14,7 @@
         - [External Overview](models/darp7/external-overview.md)
         - [Internal Overview](models/darp7/internal-overview.md)
         - [Parts & Repairs](models/darp7/repairs.md)
+    - [Eland 1U (elan1-r1)](models/elan1-r1/README.md)
     - [Galago Pro (galp5)](models/galp5/README.md)
         - [External Overview](models/galp5/external-overview.md)
         - [Internal Overview](models/galp5/internal-overview.md)

--- a/src/models/README.md
+++ b/src/models/README.md
@@ -8,6 +8,7 @@ This documentation includes the following System76 models:
 - [Adder WS (addw2)](addw2/README.md)
 - [Bonobo WS (bonw14)](bonw14/README.md)
 - [Darter Pro (darp7)](darp7/README.md)
+- [Eland 1U (elan1-r1)](elan1-r1/README.md)
 - [Galago Pro (galp5)](galp5/README.md)
 - [Gazelle (gaze17)](gaze17/README.md)
 - [Kudu (kudu6)](kudu6/README.md)

--- a/src/models/elan1-r1/README.md
+++ b/src/models/elan1-r1/README.md
@@ -1,0 +1,29 @@
+# Eland 1U (elan1-r1)
+
+![Eland 1U](./img/elan1-r1-frontports.avif)
+
+The System76 Eland 1U is a rack-mount server with the following specifications:
+
+- Operating System
+    - Ubuntu Server 22.04 LTS (64-bit)
+- CPU options
+    - Supports AMD EPYC™ 7003 series processor family
+    - Single processor
+- Memory
+    - Up to 4096GB (16x256GB) ECC DDR4 @ 3200 MHz
+- Networking
+    - 2x 1GbE LAN ports (1 x Intel® I350-AM2)
+    - 1x 10/100/1000 management LAN
+- Expansion
+    - 1 x PCIe x16 slot (Gen4)
+- Ports
+    - Front: 2 x USB 3.0, 1 x Power button with LED, 1 x ID button with LED, 1 x NMI button, 1 x Reset button, 2 x LAN activity LEDs, 1 x HDD activity LED, 1 x System status LED
+    - Rear: 3 x USB 3.0, 1 x VGA, 1 x COM, 2 x RJ45, 1 x MLAN, 1 x ID button with LED
+- Power Supply
+    - 2 x 650W redundant PSUs, 80 PLUS Platinum
+- Dimensions
+    - 17.2” × 26” × 1.7” (43.8cm × 66.0cm × 43.5cm)
+- Weight
+    - 44 lbs (17.24 kg)
+- Model
+    - elan1-r1 - [Technical Documentation](./elan1-r1_manual.pdf)

--- a/src/models/elan1-r1/elan1-r1_manual.pdf
+++ b/src/models/elan1-r1/elan1-r1_manual.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:822e27c5d2637f760792d86b3dcbff0dba58fb64c1860a0e34d0c1950e7ff8cb
+size 33646072

--- a/src/models/elan1-r1/img/elan1-r1-frontports.avif
+++ b/src/models/elan1-r1/img/elan1-r1-frontports.avif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:334e01a4836ff5b90153905f2e7003cbec559464caff942f69120e3531576e41
+size 116594


### PR DESCRIPTION
Since the servers already have technical manuals from their respective original manufacturers, I propose that this is the form tech-docs for servers will take. It is basically a mirroring of what is found on each of their current product pages. 

In this PR, I've added elan1-r1 in this fashion (product page for reference: https://system76.com/servers/eland-1u). It's pretty sparse, but I think this is a reasonable MVP to get server tech-docs created. I added the PDF manual directly to this repository so that we don't have to link to Gigabyte's site for it. I also added PDF files and avif files (seems that product images use this now, and they render in browsers, so I didn't bother converting it) to git lfs. 

Later additions could be things like labeled internal and port diagrams, more in-depth specifications on compatible hardware, etc. Most of this will be a duplication of material that is likely already in the manual, but a more friendly/convenient presentation of important pieces is probably not a bad thing.