### PR TITLE
Adds lemp9 Wi-Fi card

### DIFF
--- a/src/models/darp6/README.md
+++ b/src/models/darp6/README.md
@@ -31,9 +31,9 @@ The System76 Darter Pro is a laptop with the following specifications:
     - Up to 64GB (2x32GB) dual-channel DDR4 SO-DIMMs @ 2666 MHz
 - Networking
     - Gigabit Ethernet
-    - M.2 PCIe/CNVi WiFi/Bluetooth
+    - M.2 PCIe/CNVi WiFi/Bluetooth options:
         - Intel Wi-Fi 6 AX200/AX201
-        - or Intel Wireless-AC 9560
+        - Intel Wireless-AC 9560
 - Power
     - 65W (19V, 3.42A) DC-in port
         - Barrel size: 5.5mm (outer), 2.5mm (inner)

--- a/src/models/galp4/README.md
+++ b/src/models/galp4/README.md
@@ -31,9 +31,9 @@ The System76 Galago Pro is a laptop with the following specifications:
     - Up to 64 (2x32GB) dual-channel DDR4 SO-DIMMs @ 2666 MHz
 - Networking
     - Gigabit Ethernet
-    - M.2 PCIe/CNVi WiFi/Bluetooth
+    - M.2 PCIe/CNVi WiFi/Bluetooth options:
         - Intel Wi-Fi 6 AX200/AX201
-        - or Intel Wireless-AC 9560
+        - Intel Wireless-AC 9560
 - Power
     - 40W (19V, 2.1A) DC-in port
         - Barrel size: 4mm (outer), 1.7mm (inner)

--- a/src/models/lemp9/README.md
+++ b/src/models/lemp9/README.md
@@ -36,8 +36,9 @@ The System76 Lemur Pro is a laptop with the following specifications:
     - Channel 0: 8-GB on-board DDR4 [Samsung K4AAG165WA-BCTD](https://www.samsung.com/semiconductor/dram/ddr4/K4AAG165WA-BCTD/)
     - Channel 1: 8-GB/16-GB/32-GB DDR4 SO-DIMM
 - Networking
-    - M.2 PCIe/CNVi WiFi/Bluetooth
-        - Intel Wi-Fi 5 AC 9560
+    - M.2 PCIe/CNVi WiFi/Bluetooth options:
+        - Intel Wi-Fi 6 AX200/AX201
+        - Intel Wireless-AC 9560
 - Power
     - 19V, 3.42A (65W) DC-in port
         - Barrel size: 5.5mm (outer), 2.5mm (inner)

--- a/src/models/lemp9/README.md
+++ b/src/models/lemp9/README.md
@@ -37,6 +37,7 @@ The System76 Lemur Pro is a laptop with the following specifications:
     - Channel 1: 8-GB/16-GB/32-GB DDR4 SO-DIMM
 - Networking
     - M.2 PCIe/CNVi WiFi/Bluetooth
+        - Intel Wi-Fi 5 AC 9560
 - Power
     - 19V, 3.42A (65W) DC-in port
         - Barrel size: 5.5mm (outer), 2.5mm (inner)


### PR DESCRIPTION
This PR does the following:

- Adds the model information for the Wi-Fi card that shipped in the lemp9