### PR TITLE
Clarify DisplayPort over USB-C support is for 3060 model only

### DIFF
--- a/src/models/gaze17/README.md
+++ b/src/models/gaze17/README.md
@@ -36,9 +36,13 @@ The System76 Gazelle is a laptop with the following specifications:
         - 15.6" 1920x1080@144Hz LCD
             - LCD panel: Panda LM156LF-2F01 (or equivalent)
     - External video output:
-        - 1x HDMI
-        - 1x Mini DisplayPort 1.2
-        - 1x DisplayPort 1.4 over USB-C (RTX 3060 model only)
+        - RTX 3060 model:
+            - 1x HDMI
+            - 1x Mini DisplayPort 1.2
+            - 1x DisplayPort 1.4 over USB-C
+        - RTX 3050 Ti and 3050 models:
+            - 1x HDMI
+            - 1x Mini DisplayPort 1.2
 - Memory
     - Up to 64GB (2x32GB) dual-channel DDR4 SO-DIMMs @ 3200 MHz
 - Networking

--- a/src/models/gaze17/README.md
+++ b/src/models/gaze17/README.md
@@ -38,7 +38,7 @@ The System76 Gazelle is a laptop with the following specifications:
     - External video output:
         - 1x HDMI
         - 1x Mini DisplayPort 1.2
-        - 1x DisplayPort 1.4 over USB-C
+        - 1x DisplayPort 1.4 over USB-C (RTX 3060 model only)
 - Memory
     - Up to 64GB (2x32GB) dual-channel DDR4 SO-DIMMs @ 3200 MHz
 - Networking


### PR DESCRIPTION
If the 3060 model is the only one that supports DP over USB-C, this will close #159