### PR TITLE
Pull back advertised support for video over USB-C to only document this as working on the USB-C TB port.

### DIFF
--- a/src/models/serw13/README.md
+++ b/src/models/serw13/README.md
@@ -32,7 +32,7 @@ The System76 Serval WS is a laptop with the following specifications:
     - External video outputs:
         - 1x HDMI
         - 1x Mini DisplayPort 1.4
-        - 2x DisplayPort 1.4 over USB-C
+        - 1x DisplayPort 1.4 over USB-C
 - Memory
     - Up to 64GB (2x32GB) dual-channel DDR5 SO-DIMMs @ 5600 MHz
 - Networking
@@ -58,7 +58,6 @@ The System76 Serval WS is a laptop with the following specifications:
         - Supports USB-PD (charging) when the system is powered off or suspended.
         - Supports DisplayPort over USB-C.
     - 1x USB 3.2 Gen 2 Type-C
-        - Supports DisplayPort over USB-C.
     - 2x USB 3.2 Gen 1 Type-A
 - Dimensions
     - 15": 2.49cm x 35.8cm x 24.0cm, 2.4kg

--- a/src/models/serw13/README.md
+++ b/src/models/serw13/README.md
@@ -58,6 +58,8 @@ The System76 Serval WS is a laptop with the following specifications:
         - Supports USB-PD (charging) when the system is powered off or suspended.
         - Supports DisplayPort over USB-C.
     - 1x USB 3.2 Gen 2 Type-C
+        - Partially supports DisplayPort over USB-C.
+            - Display output is unreliable with some display brands; <br/>usage of the Thunderbolt port is recommended instead.
     - 2x USB 3.2 Gen 1 Type-A
 - Dimensions
     - 15": 2.49cm x 35.8cm x 24.0cm, 2.4kg


### PR DESCRIPTION
…is as working on the USB-C TB port.