### PR TITLE
Updated incorrect info for battery replacement in the gaze18 repairs.md

### DIFF
--- a/src/models/gaze17/repairs.md
+++ b/src/models/gaze17/repairs.md
@@ -92,8 +92,8 @@ Your Gazelle's WiFi and Bluetooth are both handled by the same module. It is a s
 
 The battery provides primary power whenever the system is unplugged.
 
-**Tools required:** None  
-**Time estimate:** 1 minute  
+**Tools required:** Cross-head (Phillips) screwdriver
+**Time estimate:** 8 minutes
 **Difficulty:** Easy <span style="color:green;">●</span>
 
 ### Steps to replace the battery:

--- a/src/models/gaze18/repairs.md
+++ b/src/models/gaze18/repairs.md
@@ -94,7 +94,7 @@ Your Gazelle's WiFi and Bluetooth are both handled by the same module. It is a s
 The battery provides primary power whenever the system is unplugged.
 
 **Tools required:** Cross-head (Phillips) screwdriver
-**Time estimate:** 1 minute
+**Time estimate:** 6 minutes
 **Difficulty:** Easy <span style="color:green;">●</span>
 
 ### Steps to replace the battery:

--- a/src/models/gaze18/repairs.md
+++ b/src/models/gaze18/repairs.md
@@ -94,7 +94,7 @@ Your Gazelle's WiFi and Bluetooth are both handled by the same module. It is a s
 The battery provides primary power whenever the system is unplugged.
 
 **Tools required:** Cross-head (Phillips) screwdriver
-**Time estimate:** 6 minutes
+**Time estimate:** 8 minutes
 **Difficulty:** Easy <span style="color:green;">●</span>
 
 ### Steps to replace the battery:

--- a/src/models/gaze18/repairs.md
+++ b/src/models/gaze18/repairs.md
@@ -93,8 +93,8 @@ Your Gazelle's WiFi and Bluetooth are both handled by the same module. It is a s
 
 The battery provides primary power whenever the system is unplugged.
 
-**Tools required:** None  
-**Time estimate:** 1 minute  
+**Tools required:** Cross-head (Phillips) screwdriver
+**Time estimate:** 1 minute
 **Difficulty:** Easy <span style="color:green;">●</span>
 
 ### Steps to replace the battery:


### PR DESCRIPTION
### Changes:

1. Replaced the tools required of "None" with phillips screwdriver.

Replacing the battery requires the use of a screwdriver to remove the bottom cover as well as to remove the five battery screws.

2. Also increased the time it takes to replace the battery.

Since removing the bottom cover is required in order to replace the battery and removing the bottom cover takes 5 minutes, the time it takes to battery must take more than 5 minutes. It said 1 minute before, so I just added 1 minute to the 5 minutes it takes to remove the bottom cover.