### PR TITLE
serw13 (specs): Lower RAM speed to 4800 MHz

### DIFF
--- a/src/models/serw13/README.md
+++ b/src/models/serw13/README.md
@@ -34,7 +34,7 @@ The System76 Serval WS is a laptop with the following specifications:
         - 1x Mini DisplayPort 1.4
         - 1x DisplayPort 1.4 over USB-C
 - Memory
-    - Up to 64GB (2x32GB) dual-channel DDR5 SO-DIMMs @ 5600 MHz
+    - Up to 64GB (2x32GB) dual-channel DDR5 SO-DIMMs @ 4800 MHz
 - Networking
     - 2.5-Gigabit Ethernet
     - M.2 PCIe/CNVi WiFi/Bluetooth


### PR DESCRIPTION
Although the upstream motherboard manual states that RAM speeds of up to 5600 MHz are supported (depending on the FSB of the CPU), testing has shown that the laptop only reports speeds of up to 4800 MHz with our current firmware, and this speed is what's currently being marketed on the sales page.

This may be revised again later if https://github.com/system76/coreboot/pull/176 is successful.

CC: @ahoneybun 