### PR TITLE
nebula19/36/49 (assembly): Rename GPU brace to side fan bracket

### DIFF
--- a/src/models/nebula19-1/assembly.md
+++ b/src/models/nebula19-1/assembly.md
@@ -8,7 +8,7 @@ The preinstalled velcro strips are left partially unwrapped to aid in removal. W
 - [Removing the top case](#removing-the-top-case)
 - [Removing the CPU shroud](#removing-the-cpu-shroud)
 - [Unpacking the included accessories](#unpacking-the-included-accessories)
-- [Installing/removing the GPU brace](#installingremoving-the-gpu-brace)
+- [Installing/removing the side fan bracket](#installingremoving-the-side-fan-bracket)
 - [Installing the motherboard](#installing-the-motherboard)
 - [Installing the CPU shroud fans](#installing-the-cpu-shroud-fans)
 - [Installing the GPU](#installing-the-gpu)
@@ -84,7 +84,7 @@ nebula19 includes the following components preinstalled:
     - Be Quiet! Pure Wings 2 92mm (`BQ PUW2-9225-MR-PWM`)
 - 2x short velcro straps
     - 1x on the side of the chassis
-    - 1x on the GPU brace
+    - 1x on the side fan bracket
 
 In addition, nebula19 ships with the following non-installed accessories:
 
@@ -98,7 +98,7 @@ In addition, nebula19 ships with the following non-installed accessories:
     - Be Quiet! Silent Wings 4 140mm (`BQ SIW4-14025-LF-PWM`)
 - 1x CPU cooler w/ fan (optional)
     - Noctua `NH-U9S` cooler w/ `NF-A9 PWM` fan
-- 1x GPU brace-mounted side fan (optional)
+- 1x Side bracket fan (optional)
     - Be Quiet! Silent Wings 4 120mm (`BQ SIW4-12025-MF-PWM`)
 
 ### Steps to unpack the included accessories:
@@ -110,38 +110,38 @@ In addition, nebula19 ships with the following non-installed accessories:
 
 3. Open the accessory boxes as needed.
 
-## Installing/removing the GPU brace:
+## Installing/removing the side fan bracket:
 
-The GPU brace provides a mounting point to help keep installed GPUs (or other PCI Express cards) in place while transporting the system. It can also be used to mount an extra intake fan, such as the optional `BQ SIW4-12025-MF-PWM`.
+The side fan bracket provides a mounting point for an extra intake fan, such as the optional `BQ SIW4-12025-MF-PWM`.
 
-If no optional accessories were ordered with the nebula19, then the GPU brace will ship preinstalled. If optional accessories were included in the order, then they will ship inside of the chassis, and the GPU brace will ship in a separate box. It can be installed after assembling the rest of the computer.
+If no optional accessories were ordered with the nebula19, then the side fan bracket will ship preinstalled. If optional accessories were included in the order, then they will ship inside of the chassis, and the side fan bracket will ship in a separate box. It can be installed after assembling the rest of the computer.
 
-![GPU brace](./img/gpu-brace.webp)
+![Side fan bracket](./img/gpu-brace.webp)
 
-The fan splitter on the GPU brace can be used for the side intake fan installed on the GPU brace as well as the bottom chassis intake fan.
+The fan splitter on the side fan bracket can be used for the side intake fan installed on the side fan bracket as well as the bottom chassis intake fan.
 
 - **Tools required:** Cross-head (Phillips) screwdriver  
 
-### Steps to unpack and install the GPU brace:
+### Steps to unpack and install the side fan bracket:
 
 1. [Remove the top case](#removing-the-top-case) and [unpack the included accessories](#unpacking-the-included-accessories).
-2. Cut the tape of the GPU brace box and remove the GPU brace and screw bag from the box.
+2. Cut the tape of the side fan bracket box and remove the side fan bracket and screw bag from the box.
 
-![GPU brace unboxing](./img/gpu-brace-unboxing.webp)
+![Side fan bracket unboxing](./img/gpu-brace-unboxing.webp)
 
-3. Screw the GPU brace into the system using the four M3 screws included with the GPU brace.
+3. Screw the side fan bracket into the system using the four M3 screws included with the side fan bracket.
     - The fan splitter board should be on the right side (with the dual headers facing outwards) and the rockets should point upwards.
 
-![GPU brace screws](./img/gpu-brace-screws.webp)
+![Side fan bracket screws](./img/gpu-brace-screws.webp)
 
-### Steps to remove the GPU brace:
+### Steps to remove the side fan bracket:
 
 1. [Remove the top case](#removing-the-top-case).
-2. Unscrew the four screws holding the GPU brace in place (two on the front of the case, two on the back.)
+2. Unscrew the four screws holding the side fan bracket in place (two on the front of the case, two on the back.)
 
-![GPU brace screws](./img/gpu-brace-screws.webp)
+![side fan bracket screws](./img/gpu-brace-screws.webp)
 
-3. Pull the GPU brace out of the chassis.
+3. Pull the side fan bracket out of the chassis.
 
 ## Installing the motherboard:
 
@@ -156,7 +156,7 @@ Four standoffs and motherboard screws are included.
 
 ### Steps to install the motherboard:
 
-1. If they are installed, [remove the top case](#removing-the-top-case), [remove the CPU shroud](#removing-the-cpu-shroud) and [remove the GPU brace](#installingremoving-the-gpu-brace).
+1. If they are installed, [remove the top case](#removing-the-top-case), [remove the CPU shroud](#removing-the-cpu-shroud) and [remove the side fan bracket](#installingremoving-the-side-fan-bracket).
 2. Locate the standoffs and M3 screws from the brown screw and velcro box.
 
 ![Standoffs and M3 screws](./img/standoffs-screws.webp)
@@ -232,7 +232,7 @@ These instructions also apply to other PCI Express cards, such as add-in sound c
 ### Steps to install the GPU:
 
 1. If not already installed, [install the motherboard](#installing-the-motherboard).
-    - If the motherboard is already installed and the system is assembled, then [remove the top case](#removing-the-top-case) and [remove the GPU brace](#installingremoving-the-gpu-brace).
+    - If the motherboard is already installed and the system is assembled, then [remove the top case](#removing-the-top-case) and [remove the side fan bracket](#installingremoving-the-side-fan-bracket).
 2. Unscrew the two screws holding the PCIe bracket onto the chassis, then remove the bracket.
 
 ![PCIe Bracket](./img/pcie-bracket.webp)
@@ -253,7 +253,7 @@ nebula19 is designed to work with an optional SATA backplane to allow for easy h
 ### Steps to install the SATA backplane:
 
 1. [Remove the top case](#removing-the-top-case).
-    - The [GPU brace](#installingremoving-the-gpu-brace) can also be removed for easier access to the SATA backplane screws and wiring.
+    - The [side fan bracket](#installingremoving-the-side-fan-bracket) can also be removed for easier access to the SATA backplane screws and wiring.
 2. Unscrew and remove the 2.5" drive cage's cover.
 
 ![2.5" SATA drive cage cover](./img/25-drive-cover.webp)
@@ -270,7 +270,7 @@ nebula19 is designed to work with an optional SATA backplane to allow for easy h
 
 6. Connect the white `POWER0` header on the back of the SATA backplane to the power supply, and the black `DATA0` and `DATA1` ports to two of the motherboard's SATA ports.
     - The `POWER0` header uses a four-pin Berg connector, also known as a floppy drive power connector.
-7. [Install any 2.5" SATA drives](#installing-25-drives) and replace the drive cage cover, GPU brace (if necessary), and top case.
+7. [Install any 2.5" SATA drives](#installing-25-drives) and replace the drive cage cover, side fan bracket (if necessary), and top case.
 
 ## Installing 2.5" drives:
 
@@ -299,7 +299,7 @@ The case includes a 140mm Be Quiet! Silent Wings 4 `BQ SIW4-14025-LF-PWM` fan (n
 
 ### Steps to replace the bottom case fan:
 
-1. [Remove the top case](#removing-the-top-case) and [remove the GPU brace](#installingremoving-the-gpu-brace).
+1. [Remove the top case](#removing-the-top-case) and [remove the side fan bracket](#installingremoving-the-side-fan-bracket).
 2. Remove the fan, dust filter, and fan screws from the 140mm fan box.
 
 ![Bottom fan unboxing](./img/bottom-fan-unboxing.webp)
@@ -315,25 +315,25 @@ The case includes a 140mm Be Quiet! Silent Wings 4 `BQ SIW4-14025-LF-PWM` fan (n
 
 ## Installing side intake fan:
 
-nebula19 supports one 120mm side intake fan mounted to the GPU brace. A 120mm Be Quiet! Silent Wings 4 fan (`BQ SIW4-12025-MF-PWM`) is available as an optional add-on at the time of purchase.
+nebula19 supports one 120mm side intake fan mounted to the side fan bracket. A 120mm Be Quiet! Silent Wings 4 fan (`BQ SIW4-12025-MF-PWM`) is available as an optional add-on at the time of purchase.
 
 ### Steps to install the side intake fan:
 
-1. [Remove the top case](#removing-the-top-case) and [remove the GPU brace](#installingremoving-the-gpu-brace).
+1. [Remove the top case](#removing-the-top-case) and [remove the side fan bracket](#installingremoving-the-side-fan-bracket).
 2. Unpack the fan, dust filter, and fan screws from the fan box.
 
 ![Be Quiet! Silent Wings 4 120mm Box](./img/side-fan-unboxing.webp)
 
-3. Place the dust filter and fan in the desired position along the GPU brace.
-    - The shiny side of the dust filter should face the GPU brace.
+3. Place the dust filter and fan in the desired position along the side fan bracket.
+    - The shiny side of the dust filter should face the side fan bracket.
     - The spinning side of the fan should face outward, while the stationary label should face inward.
-    - The fan wire should be oriented towards the fan splitter board on the GPU brace.
-4. From the back, screw the fan screws through the GPU brace and into the fan.
-5. Plug the side fan into one of the headers on the GPU brace's fan splitter board. The nearby velcro strap can be used to hold the fan's cable.
+    - The fan wire should be oriented towards the fan splitter board on the side fan bracket.
+4. From the back, screw the fan screws through the side fan bracket and into the fan.
+5. Plug the side fan into one of the headers on the side fan bracket's fan splitter board. The nearby velcro strap can be used to hold the fan's cable.
 
 ![Mounted side fan](./img/side-fan-mounted.webp)
 
-6. Replace the GPU brace and top case.
+6. Replace the side fan bracket and top case.
 
 ## Installing the power supply:
 
@@ -343,7 +343,7 @@ The system supports standard ATX power supplies. nebula19 includes a [dust filte
 
 ### Steps to install the power supply:
 
-1. [Remove the top case](#removing-the-top-case) and [remove the GPU brace](#installingremoving-the-gpu-brace).
+1. [Remove the top case](#removing-the-top-case) and [remove the side fan bracket](#installingremoving-the-side-fan-bracket).
 2. Place the power supply into the chassis with the fan facing down.
 3. While holding the power supply against the back of the chassis, screw in the four power supply screws.
     - Power supply screws are typically included with the power supply, and are not included with nebula19.

--- a/src/models/nebula36-1/assembly.md
+++ b/src/models/nebula36-1/assembly.md
@@ -6,7 +6,7 @@ The preinstalled velcro strips are left partially unwrapped to aid in removal. W
 
 - [Replacing the front accent strip](#replacing-the-front-accent-strip)
 - [Removing the top case](#removing-the-top-case)
-- [Removing the GPU brace](#removing-the-gpu-brace)
+- [Removing the side fan bracket](#removing-the-side-fan-bracket)
 - [Removing the CPU shroud](#removing-the-cpu-shroud)
 - [Unpacking the included accessories](#unpacking-the-included-accessories)
 - [Installing the motherboard](#installing-the-motherboard)
@@ -50,24 +50,24 @@ The top case can be removed to access the internal components.
 
 2. Slide the top case up and off of the machine.
 
-## Removing the GPU brace:
+## Removing the side fan bracket:
 
-The GPU brace provides a mounting point to help keep installed GPUs (or other PCI Express cards) in place while transporting the system. It can also be used to mount up to two extra intake fans (one, a `BQ SIW4-12025-MF-PWM`, is optional when purchasing the chassis; a second is not included.)
+The side fan bracket provides a mounting point to help keep installed GPUs (or other PCI Express cards) in place while transporting the system. It can also be used to mount up to two extra intake fans (one, a `BQ SIW4-12025-MF-PWM`, is optional when purchasing the chassis; a second is not included.)
 
-![GPU brace](./img/gpu-brace.webp)
+![Side fan bracket](./img/gpu-brace.webp)
 
-The fan splitter on the GPU brace is intended for fans mounted on the GPU brace, and should not be used for the CPU shroud fans or the bottom intake fan.
+The fan splitter on the side fan bracket is intended for fans mounted on the side fan bracket, and should not be used for the CPU shroud fans or the bottom intake fan.
 
 - **Tools required:** Cross-head (Phillips) screwdriver  
 
-### Steps to remove the GPU brace:
+### Steps to remove the side fan bracket:
 
 1. Follow the steps above to [remove the top case](#removing-the-top-case).
-2. Unscrew the four screws holding the GPU brace in place (two on the front of the case, two on the back.)
+2. Unscrew the four screws holding the side fan bracket in place (two on the front of the case, two on the back.)
 
-![GPU brace screws](./img/gpu-brace-screws.webp)
+![Side fan bracket screws](./img/gpu-brace-screws.webp)
 
-3. Pull the GPU brace out of the chassis.
+3. Pull the side fan bracket out of the chassis.
 
 ## Removing the CPU shroud:
 
@@ -108,7 +108,7 @@ nebula36 includes the following components preinstalled:
     - 3x on the side of the chassis
     - 1x on the bottom of the chassis
     - 1x on the CPU shroud
-    - 1x on the GPU brace
+    - 1x on the side fan bracket
 
 In addition, nebula36 ships with the following non-installed accessories:
 
@@ -120,12 +120,12 @@ In addition, nebula36 ships with the following non-installed accessories:
     - 4x fan screws
 - 1x CPU cooler w/ fan (optional)
     - Noctua `NH-U12S` w/ `NF-F12 PWM` fan
-- 1x GPU brace-mounted side fan (optional)
+- 1x Side bracket fan (optional)
     - Be Quiet! Silent Wings 4 120mm (`BQ SIW4-12025-MF-PWM`)
 
 ### Steps to unpack the included accessories:
 
-1. Follow the steps above to [remove the top case](#removing-the-top-case), [remove the GPU brace](#removing-the-gpu-brace), and [remove the CPU shroud](#removing-the-cpu-shroud).
+1. Follow the steps above to [remove the top case](#removing-the-top-case), [remove the side fan bracket](#removing-the-side-fan-bracket), and [remove the CPU shroud](#removing-the-cpu-shroud).
 2. Cut the zip ties holding the accessory boxes in place.
     - The image below highlights where the zip ties are joined; they can be cut anywhere, but must be cut between a joint and the chassis in order to be removed.
 
@@ -149,7 +149,7 @@ Nine standoffs and motherboard screws are included.
 
 ### Steps to install the motherboard:
 
-1. If they are installed, [remove the top case](#removing-the-top-case), [remove the CPU shroud](#removing-the-cpu-shroud) and [remove the GPU brace](#removing-the-gpu-brace).
+1. If they are installed, [remove the top case](#removing-the-top-case), [remove the CPU shroud](#removing-the-cpu-shroud) and [remove the side fan bracket](#removing-the-side-fan-bracket).
 2. Locate the standoffs and M3 screws from the brown screw and velcro box.
 
 ![Standoffs and M3 screws](./img/standoffs-screws.webp)
@@ -230,7 +230,7 @@ These instructions also apply to other PCI Express cards, such as add-in sound c
 ### Steps to install the GPU:
 
 1. If not already installed, [install the motherboard](#installing-the-motherboard).
-    - If the motherboard is already installed and the system is assembled, then [remove the top case](#removing-the-top-case) and [remove the GPU brace](#removing-the-gpu-brace).
+    - If the motherboard is already installed and the system is assembled, then [remove the top case](#removing-the-top-case) and [remove the side fan bracket](#removing-the-side-fan-bracket).
 2. Unscrew the two screws holding the PCIe bracket onto the chassis, then remove the bracket.
 
 ![PCIe Bracket](./img/pcie-bracket.webp)
@@ -272,7 +272,7 @@ nebula36 is designed to work with an optional SATA backplane to allow for easy h
 
 ![2.5" SATA backplane headers](./img/sata-backplane-headers.webp)
 
-9. [Install any 2.5" SATA drives](#installing-25-drives) and replace the drive cage cover, GPU brace (if necessary), and top case.
+9. [Install any 2.5" SATA drives](#installing-25-drives) and replace the drive cage cover, side fan bracket (if necessary), and top case.
 
 ## Installing 2.5" drives:
 
@@ -305,7 +305,7 @@ The 140mm bottom case fan (`BQ SIW4-14025-LF-PWM`) is preinstalled, but can be r
 ### Steps to replace the bottom case fan:
 
 1. [Remove the top case](#removing-the-top-case).
-    - The [side GPU brace](#removing-the-gpu-brace) can optionally be removed to make working with the fan easier.
+    - The [side fan bracket](#removing-the-side-fan-bracket) can optionally be removed to make working with the fan easier.
 2. If the system is already assembled, unplug the fan from the fan splitter board or motherboard.
 3. Set the machine down on its side and unscrew the four fan screws.
 
@@ -315,7 +315,7 @@ The 140mm bottom case fan (`BQ SIW4-14025-LF-PWM`) is preinstalled, but can be r
 
 ## Installing side intake fans:
 
-nebula36 supports up to two 120mm side intake fans mounted to the GPU brace. One 120mm fan (`BQ SIW4-12025-MF-PWM`) is sold as an optional add-on at the time of purchase.
+nebula36 supports up to two 120mm side intake fans mounted to the side fan bracket. One 120mm fan (`BQ SIW4-12025-MF-PWM`) is sold as an optional add-on at the time of purchase.
 
 ### Steps to install the side intake fans:
 
@@ -325,15 +325,15 @@ nebula36 supports up to two 120mm side intake fans mounted to the GPU brace. One
 
 ![Be Quiet! Silent Wings 4 120mm Box](./img/side-fan-box.webp)
 
-3. Place the fan in the center of the GPU brace.
+3. Place the fan in the center of the side fan bracket.
     - The spinning side of the fan should face outward, while the stationary label should face inward.
-    - The preinstalled pinholes on the fan will line up with the long holes in the GPU brace.
+    - The preinstalled pinholes on the fan will line up with the long holes in the side fan bracket.
 4. From the back (inside of the machine), insert the rubber mounting pins through the pinholes at each corner of the fan.
-    - The GPU brace can optionally be [removed](#removing-the-gpu-brace) to make working with the rubber mounting pins easier.
+    - The side fan bracket can optionally be [removed](#removing-the-side-fan-bracket) to make working with the rubber mounting pins easier.
 
 ![Mounted side fan](./img/side-fan-mounted.webp)
 
-5. Plug the side fan into one of the headers on the GPU brace's fan splitter board. The nearby velcro strap can be used to hold the fan's cable.
+5. Plug the side fan into one of the headers on the side fan bracket's fan splitter board. The nearby velcro strap can be used to hold the fan's cable.
 
 ## Installing the power supply:
 
@@ -344,7 +344,7 @@ The system supports standard ATX power supplies. nebula36 includes a [dust filte
 ### Steps to install the power supply:
 
 1. [Remove the top case](#removing-the-top-case).
-    - The [side GPU brace](#removing-the-gpu-brace) can optionally be removed to make working with the power supply easier.
+    - The [side fan bracket](#removing-the-side-fan-bracket) can optionally be removed to make working with the power supply easier.
 2. Place the power supply into the chassis with the fan facing down.
 3. While holding the power supply against the back of the chassis, screw in the four power supply screws.
     - Power supply screws are typically included with the power supply, and are not included with nebula36.

--- a/src/models/nebula49-1/assembly.md
+++ b/src/models/nebula49-1/assembly.md
@@ -6,7 +6,7 @@ The preinstalled velcro strips are left partially unwrapped to aid in removal. W
 
 - [Replacing the front accent strip](#replacing-the-front-accent-strip)
 - [Removing the top case](#removing-the-top-case)
-- [Removing the GPU brace](#removing-the-gpu-brace)
+- [Removing the side fan bracket](#removing-the-side-fan-bracket)
 - [Removing the CPU shroud](#removing-the-cpu-shroud)
 - [Unpacking the included accessories](#unpacking-the-included-accessories)
 - [Installing the motherboard](#installing-the-motherboard)
@@ -50,24 +50,24 @@ The top case can be removed to access the internal components.
 
 2. Slide the top case up and off of the machine.
 
-## Removing the GPU brace:
+## Removing the side fan bracket:
 
-The GPU brace provides a mounting point to help keep installed GPUs (or other PCI Express cards) in place while transporting the system. It can also be used to mount up to two extra intake fans (two `BQ SIW4-12025-MF-PWM` fans are optional when purchasing the chassis.)
+The side fan bracket provides a mounting point to help keep installed GPUs (or other PCI Express cards) in place while transporting the system. It can also be used to mount up to two extra intake fans (two `BQ SIW4-12025-MF-PWM` fans are optional when purchasing the chassis.)
 
-![GPU brace](./img/gpu-brace.webp)
+![Side fan bracket](./img/gpu-brace.webp)
 
-The fan splitter on the GPU brace is intended for fans mounted on the GPU brace, and should not be used for the CPU shroud fans or the bottom intake fan.
+The fan splitter on the side fan bracket is intended for fans mounted on the side fan bracket, and should not be used for the CPU shroud fans or the bottom intake fan.
 
 - **Tools required:** Cross-head (Phillips) screwdriver  
 
-### Steps to remove the GPU brace:
+### Steps to remove the side fan bracket:
 
 1. Follow the steps above to [remove the top case](#removing-the-top-case).
-2. Unscrew the four screws holding the GPU brace in place (two on the front of the case, two on the back.)
+2. Unscrew the four screws holding the side fan bracket in place (two on the front of the case, two on the back.)
 
-![GPU brace screws](./img/gpu-brace-screws.webp)
+![Side fan bracket screws](./img/gpu-brace-screws.webp)
 
-3. Pull the GPU brace out of the chassis.
+3. Pull the side fan bracket out of the chassis.
 
 ## Removing the CPU shroud:
 
@@ -106,7 +106,7 @@ nebula49 includes the following components preinstalled:
 - 4x Short velcro straps
     - 2x on the side of the chassis
     - 1x on the bottom of the chassis
-    - 1x on the GPU brace
+    - 1x on the side fan bracket
 
 In addition, nebula49 ships with the following non-installed accessories:
 
@@ -118,12 +118,12 @@ In addition, nebula49 ships with the following non-installed accessories:
     - 4x Fan screws
 - 1x CPU cooler w/ fan (optional)
     - Noctua `NH-U12S` w/ `NF-F12 PWM` fan
-- 2x GPU brace-mounted side fans (optional)
+- 2x side bracket fans (optional)
     - Be Quiet! Silent Wings 4 120mm (`BQ SIW4-12025-MF-PWM`)
 
 ### Steps to unpack the included accessories:
 
-1. Follow the steps above to [remove the top case](#removing-the-top-case), [remove the GPU brace](#removing-the-gpu-brace), and [remove the CPU shroud](#removing-the-cpu-shroud).
+1. Follow the steps above to [remove the top case](#removing-the-top-case), [remove the side fan bracket](#removing-the-side-fan-bracket), and [remove the CPU shroud](#removing-the-cpu-shroud).
 2. Cut the zip ties holding the accessory boxes in place.
     - The image below highlights where the zip ties are joined; they can be cut anywhere, but must be cut between a joint and the chassis in order to be removed.
 
@@ -147,7 +147,7 @@ Nine standoffs and motherboard screws are included.
 
 ### Steps to install the motherboard:
 
-1. If they are installed, [remove the top case](#removing-the-top-case), [remove the CPU shroud](#removing-the-cpu-shroud) and [remove the GPU brace](#removing-the-gpu-brace).
+1. If they are installed, [remove the top case](#removing-the-top-case), [remove the CPU shroud](#removing-the-cpu-shroud) and [remove the side fan bracket](#removing-the-side-fan-bracket).
 2. Locate the standoffs and M3 screws from the brown screw and velcro box.
 
 ![Standoffs and M3 screws](./img/standoffs-screws.webp)
@@ -225,7 +225,7 @@ These instructions also apply to other PCI Express cards, such as add-in sound c
 ### Steps to install the GPU:
 
 1. If not already installed, [install the motherboard](#installing-the-motherboard).
-    - If the motherboard is already installed and the system is assembled, then [remove the top case](#removing-the-top-case) and [remove the GPU brace](#removing-the-gpu-brace).
+    - If the motherboard is already installed and the system is assembled, then [remove the top case](#removing-the-top-case) and [remove the side fan bracket](#removing-the-side-fan-bracket).
 2. Unscrew the two screws holding the PCIe bracket onto the chassis, then remove the bracket.
 
 ![PCIe Bracket](./img/pcie-bracket.webp)
@@ -269,7 +269,7 @@ Each 2.5" drive cage in nebula49 is designed to work with an optional SATA backp
 
 ![2.5" SATA backplane headers](./img/sata-backplane-headers.webp)
 
-9. [Install any 2.5" SATA drives](#installing-25-drives) and replace the drive cage cover, GPU brace (if necessary), and top case.
+9. [Install any 2.5" SATA drives](#installing-25-drives) and replace the drive cage cover, side fan bracket (if necessary), and top case.
 
 ## Installing 2.5" drives:
 
@@ -302,7 +302,7 @@ The 140mm bottom case fan (`BQ SIW4-14025-LF-PWM`) is preinstalled, but can be r
 ### Steps to replace the bottom case fan:
 
 1. [Remove the top case](#removing-the-top-case).
-    - The [side GPU brace](#removing-the-gpu-brace) can optionally be removed to make working with the fan easier.
+    - The [side fan bracket](#removing-the-side-fan-bracket) can optionally be removed to make working with the fan easier.
 2. If the system is already assembled, unplug the fan from the fan splitter board or motherboard.
 3. Set the machine down on its side and unscrew the four fan screws.
 
@@ -312,7 +312,7 @@ The 140mm bottom case fan (`BQ SIW4-14025-LF-PWM`) is preinstalled, but can be r
 
 ## Installing side intake fans:
 
-nebula49 supports up to two 120mm side intake fans mounted to the GPU brace. Two 120mm fans (`BQ SIW4-12025-MF-PWM`) are sold as an optional add-on at the time of purchase.
+nebula49 supports up to two 120mm side intake fans mounted to the side fan bracket. Two 120mm fans (`BQ SIW4-12025-MF-PWM`) are sold as an optional add-on at the time of purchase.
 
 ### Steps to install the side intake fans:
 
@@ -322,15 +322,15 @@ nebula49 supports up to two 120mm side intake fans mounted to the GPU brace. Two
 
 ![Be Quiet! Silent Wings 4 120mm Box](./img/side-fan-unboxing.webp)
 
-3. Place the fan in the desired position along the GPU brace.
+3. Place the fan in the desired position along the side fan bracket.
     - The spinning side of the fan should face outward, while the stationary label should face inward.
-    - The preinstalled pinholes on the fan will line up with the long holes in the GPU brace.
+    - The preinstalled pinholes on the fan will line up with the long holes in the side fan bracket.
 4. From the back (inside of the machine), insert the rubber mounting pins through the pinholes at each corner of the fan.
-    - The GPU brace can optionally be [removed](#removing-the-gpu-brace) to make working with the rubber mounting pins easier.
+    - The side fan bracket can optionally be [removed](#removing-the-side-fan-bracket) to make working with the rubber mounting pins easier.
 
 ![Mounted side fan](./img/side-fan-mounted.webp)
 
-5. Plug the side fan into one of the headers on the GPU brace's fan splitter board. The nearby velcro strap can be used to hold the fan's cable.
+5. Plug the side fan into one of the headers on the side fan bracket's fan splitter board. The nearby velcro strap can be used to hold the fan's cable.
 6. Repeat the steps for a second fan, if desired.
 
 ## Installing the power supply:
@@ -342,7 +342,7 @@ The system supports standard ATX power supplies. nebula49 includes a [dust filte
 ### Steps to install the power supply:
 
 1. [Remove the top case](#removing-the-top-case).
-    - The [side GPU brace](#removing-the-gpu-brace) can optionally be removed to make working with the power supply easier.
+    - The [side fan bracket](#removing-the-side-fan-bracket) can optionally be removed to make working with the power supply easier.
 2. Place the power supply into the chassis with the fan facing down.
 3. While holding the power supply against the back of the chassis, screw in the four power supply screws.
     - Power supply screws are typically included with the power supply, and are not included with nebula49.


### PR DESCRIPTION
We don't intend to provide GPU brace fingers for Nebula, and people have gotten confused about why it's called a GPU brace if it doesn't directly brace the GPU vertically, so we're renaming it to something more reflective of its actual usage, which is apparently only to hold the side fans (which we recommend to be intake, but at least one person has already wanted to use for exhaust instead.)