### PR TITLE
nebula49-1: Remove EATX motherboard compatibility

### DIFF
--- a/src/models/nebula49-1/README.md
+++ b/src/models/nebula49-1/README.md
@@ -11,7 +11,6 @@ The System76 Nebula 49 is a desktop chassis (for DIY builds) with the following 
     - Size: 46.2cm × 26.2cm × 40.8cm
     - Volume: 49 litres
 - Motherboard sizes
-    - Extended ATX
     - ATX
     - Mini-DTX
     - DTX

--- a/src/models/nebula49-1/assembly.md
+++ b/src/models/nebula49-1/assembly.md
@@ -135,7 +135,6 @@ In addition, nebula49 ships with the following non-installed accessories:
 
 nebula49 supports the following standard motherboard sizes:
 
-- Extended ATX
 - ATX
 - Mini-DTX
 - DTX
@@ -155,7 +154,7 @@ Nine standoffs and motherboard screws are included.
 3. Insert the standoffs into the appropriate holes for your motherboard size. In the photo below, the standoff holes are labeled by color:
     - Mini-ITX and Mini-DTX: green
     - DTX: green and cyan
-    - ATX and EATX: green, cyan, and red (all holes)
+    - ATX: green, cyan, and red (all holes)
 
 ![Standoff holes](./img/standoff-holes.webp)
 


### PR DESCRIPTION
It was discovered that EATX is not actually compatible (due to the top PCIe cutout not being present), so it was removed from the sales page and should be removed from tech docs as well. A `nebula49-2` with fixed EATX compatibility is planned.