### PR TITLE
darp9 (repairs): Update RAM speed on repairs page to match specs

### DIFF
--- a/src/models/darp9/repairs.md
+++ b/src/models/darp9/repairs.md
@@ -35,7 +35,7 @@ Removing the cover is required to access the internal components. Prior to remov
 
 ## Replacing the RAM:
 
-The Darter Pro 9 supports up to 64GB (2x32GB) of DDR5 SO-DIMMs running at 5600MHz. If you've purchased new RAM, need to replace your RAM, or are reseating your RAM, follow these steps.
+The Darter Pro 9 supports up to 64GB (2x32GB) of DDR5 SO-DIMMs running at 5200MHz. If you've purchased new RAM, need to replace your RAM, or are reseating your RAM, follow these steps.
 
 **Tools required:** Cross-head (Phillips) screwdriver  
 **Time estimate:** 10 minutes  


### PR DESCRIPTION
Missed this when reviewing https://github.com/system76/tech-docs/pull/201.