### PR TITLE
nebula49-1: Specify that EATX support is up to 10.7" wide

### DIFF
--- a/src/models/nebula49-1/README.md
+++ b/src/models/nebula49-1/README.md
@@ -11,7 +11,7 @@ The System76 Nebula 49 is a desktop chassis (for DIY builds) with the following 
     - Size: 46.2cm × 26.2cm × 40.8cm
     - Volume: 49 litres
 - Motherboard sizes
-    - Extended ATX
+    - Extended ATX (up to 10.7")
     - ATX
     - Mini-DTX
     - DTX

--- a/src/models/nebula49-1/assembly.md
+++ b/src/models/nebula49-1/assembly.md
@@ -135,7 +135,7 @@ In addition, nebula49 ships with the following non-installed accessories:
 
 nebula49 supports the following standard motherboard sizes:
 
-- Extended ATX
+- Extended ATX (up to 10.7")
 - ATX
 - Mini-DTX
 - DTX


### PR DESCRIPTION
Many EATX boards [do not follow the SSI-EEB spec](https://www.gamersnexus.net/guides/3566-e-atx-is-a-lie-vs-xl-atx-eeb-ceb) of 13", and are varying lengths between regular ATX and a full 13". Mechanical engineering tells us that the nebula49-1 supports boards up to 10.7" in length (measuring from the I/O cutout towards the front of the case.)

The height for all ATX and EATX boards is 12", so having only the width specified seems to be the common convention.