### PR TITLE
pang12 (repairs): Note possibility of an adhesive cover on the heatsink

### DIFF
--- a/src/models/pang12/repairs.md
+++ b/src/models/pang12/repairs.md
@@ -131,7 +131,7 @@ Depending on your climate and the age of the machine, it may be necessary to app
 ### Steps to replace the fan/heatsink/thermal paste:
 
 1. Follow the steps above to [remove the bottom cover](#removing-the-bottom-cover).
-2. Remove any black tape that may be covering the fan screws and wires.
+2. If a black adhesive sheet is present between the fans, peel it off. Also remove any black tape that may be covering the fan screws and wires.
 3. Remove the six fan screws, highlighted green below.
 
 ![Thermal screws](./img/thermal-system.webp)


### PR DESCRIPTION
Emdoor added an additional adhesive sheet in the latest shipment. We're not sure what its purpose is yet.

It covers the heatsink screws and one of the fan connectors, so it's not possible for someone to accidentally leave it on if they're trying to remove this part, and the photo of the screw locations should hint that it needs to be removed; this just adds some confirmation that there may be an extra piece to peel off.