### PR TITLE
Correct wireless card M.2 key type in all sections

### DIFF
--- a/src/models/addw1/repairs.md
+++ b/src/models/addw1/repairs.md
@@ -213,7 +213,7 @@ The battery provides primary power whenever the system is unplugged.
 
 ## Replacing the wireless card
 
-Your Adder WS's WiFi and Bluetooth are both handled by the same module. It is a standard M.2 2230 slot with PCIe and USB interfaces (A Key).
+Your Adder WS's WiFi and Bluetooth are both handled by the same module. It is a standard M.2 2230 slot with PCIe and USB interfaces (E-key).
 
 **Tools required:** Cross-head (Phillips) screwdriver    
 **Time estimate:** 5 minutes    

--- a/src/models/addw2/repairs.md
+++ b/src/models/addw2/repairs.md
@@ -153,7 +153,7 @@ This model supports one 2.5" (7mm height) SATA III SSD or hard drive.
 
 ## Replacing the wireless card:
 
-Your Adder WS's WiFi and Bluetooth are both handled by the same module. It is a standard M.2 2230 slot with PCIe and USB interfaces (A Key).
+Your Adder WS's WiFi and Bluetooth are both handled by the same module. It is a standard M.2 2230 slot with PCIe and USB interfaces (E-key).
 
 **Tools required:** Cross-head (Phillips) screwdriver  
 **Time estimate:** 12 minutes  

--- a/src/models/addw3/repairs.md
+++ b/src/models/addw3/repairs.md
@@ -89,7 +89,7 @@ The battery provides primary power whenever the system is unplugged.
 
 ## Replacing the wireless card:
 
-Your Adder WS's WiFi and Bluetooth are both handled by the same module. It is a standard M.2 2230 slot with PCIe and USB interfaces (A Key).
+Your Adder WS's WiFi and Bluetooth are both handled by the same module. It is a standard M.2 2230 slot with PCIe and USB interfaces (E-key).
 
 **Tools required:** Cross-head (Phillips) screwdriver  
 **Time estimate:** 10 minutes  

--- a/src/models/bonw14/repairs.md
+++ b/src/models/bonw14/repairs.md
@@ -132,7 +132,7 @@ _In the above photo, the red slot is SATA only, the yellow slot is PCIe NVMe onl
 
 ## Replacing the wireless card:
 
-Your Bonobo WS's WiFi and Bluetooth are both handled by the same module. It is a standard M.2 2230 slot with PCIe and USB interfaces (A Key).
+Your Bonobo WS's WiFi and Bluetooth are both handled by the same module. It is a standard M.2 2230 slot with PCIe and USB interfaces (E-key).
 
 **Tools required:** Cross-head (Phillips) screwdriver  
 **Time estimate:** 10 minutes  

--- a/src/models/bonw15/repairs.md
+++ b/src/models/bonw15/repairs.md
@@ -93,7 +93,7 @@ This model supports up to three M.2 SSDs. All M.2 slots are size 2280 and suppor
 
 ## Replacing the wireless card:
 
-Your Bonobo WS's WiFi and Bluetooth are both handled by the same module. It is a standard M.2 2230 slot with PCIe and USB interfaces (A Key).
+Your Bonobo WS's WiFi and Bluetooth are both handled by the same module. It is a standard M.2 2230 slot with PCIe and USB interfaces (E-key).
 
 **Tools required:** Cross-head (Phillips) screwdriver  
 **Time estimate:** 10 minutes  

--- a/src/models/darp6/repairs.md
+++ b/src/models/darp6/repairs.md
@@ -127,7 +127,7 @@ This model supports one M.2 SSD of size 2280, either SATA III or PCIe NVMe Gener
 
 ## Replacing the wireless card:
 
-Your Darter Pro's WiFi and Bluetooth are both handled by the same module. It is a standard M.2 2230 slot with PCIe and USB interfaces (A Key).
+Your Darter Pro's WiFi and Bluetooth are both handled by the same module. It is a standard M.2 2230 slot with PCIe and USB interfaces (E-key).
 
 **Tools required:** Cross-head (Phillips) screwdriver  
 **Time estimate:** 12 minutes  

--- a/src/models/darp7/repairs.md
+++ b/src/models/darp7/repairs.md
@@ -74,7 +74,7 @@ This model supports two M.2 SSDs. Both slots are size 2280. SSD-1 supports PCIe 
 
 ## Replacing the wireless card:
 
-Your Darter Pro's WiFi and Bluetooth are both handled by the same module. It is a standard M.2 2230 slot with PCIe and USB interfaces (A Key).
+Your Darter Pro's WiFi and Bluetooth are both handled by the same module. It is a standard M.2 2230 slot with PCIe and USB interfaces (E-key).
 
 **Tools required:** Cross-head (Phillips) screwdriver  
 **Time estimate:** 12 minutes  

--- a/src/models/darp8/repairs.md
+++ b/src/models/darp8/repairs.md
@@ -74,7 +74,7 @@ This model supports two M.2 SSDs. Both slots are size 2280. SSD-1 supports PCIe 
 
 ## Replacing the wireless card:
 
-Your Darter Pro's WiFi and Bluetooth are both handled by the same module. It is a standard M.2 2230 slot with PCIe and USB interfaces (A Key).
+Your Darter Pro's WiFi and Bluetooth are both handled by the same module. It is a standard M.2 2230 slot with PCIe and USB interfaces (E-key).
 
 **Tools required:** Cross-head (Phillips) screwdriver  
 **Time estimate:** 12 minutes  

--- a/src/models/darp9/repairs.md
+++ b/src/models/darp9/repairs.md
@@ -75,7 +75,7 @@ This model supports two M.2 SSDs. Both slots are size 2280 and support PCIe NVMe
 
 ## Replacing the wireless card:
 
-Your Darter Pro's WiFi and Bluetooth are both handled by the same module. It is a standard M.2 2230 slot with PCIe and USB interfaces (A Key).
+Your Darter Pro's WiFi and Bluetooth are both handled by the same module. It is a standard M.2 2230 slot with PCIe and USB interfaces (E-key).
 
 **Tools required:** Cross-head (Phillips) screwdriver  
 **Time estimate:** 12 minutes  

--- a/src/models/galp4/repairs.md
+++ b/src/models/galp4/repairs.md
@@ -146,7 +146,7 @@ This model supports one 2.5" (7mm) SATA III SSD or HDD.
 
 ## Replacing the wireless card:
 
-Your Galago Pro's WiFi and Bluetooth are both handled by the same module. It is a standard M.2 2230 slot with PCIe and USB interfaces (A Key).
+Your Galago Pro's WiFi and Bluetooth are both handled by the same module. It is a standard M.2 2230 slot with PCIe and USB interfaces (E-key).
 
 **Tools required:** Cross-head (Phillips) screwdriver  
 **Time estimate:** 12 minutes  

--- a/src/models/galp5/repairs.md
+++ b/src/models/galp5/repairs.md
@@ -86,7 +86,7 @@ This model supports one M.2 SSD of size 2280, PCIe NVMe Generation 4 (or Generat
 
 ## Replacing the wireless card:
 
-Your Galago Pro's WiFi and Bluetooth are both handled by the same module. It is a standard M.2 2230 slot with PCIe and USB interfaces (A Key).
+Your Galago Pro's WiFi and Bluetooth are both handled by the same module. It is a standard M.2 2230 slot with PCIe and USB interfaces (E-key).
 
 **Tools required:** Cross-head (Phillips) screwdriver  
 **Time estimate:** 12 minutes  

--- a/src/models/galp6/repairs.md
+++ b/src/models/galp6/repairs.md
@@ -87,7 +87,7 @@ This model supports one M.2 SSD of size 2280, PCIe NVMe Generation 4 (or Generat
 
 ## Replacing the wireless card:
 
-Your Galago Pro's WiFi and Bluetooth are both handled by the same module. It is a standard M.2 2230 slot with PCIe and USB interfaces (A Key).
+Your Galago Pro's WiFi and Bluetooth are both handled by the same module. It is a standard M.2 2230 slot with PCIe and USB interfaces (E-key).
 
 **Tools required:** Cross-head (Phillips) screwdriver  
 **Time estimate:** 12 minutes  

--- a/src/models/galp7/repairs.md
+++ b/src/models/galp7/repairs.md
@@ -87,7 +87,7 @@ This model supports one M.2 SSD of size 2280 with a PCIe NVMe Generation 4 inter
 
 ## Replacing the wireless card:
 
-Your Galago Pro's WiFi and Bluetooth are both handled by the same module. It is a standard M.2 2230 slot with PCIe and USB interfaces (A Key).
+Your Galago Pro's WiFi and Bluetooth are both handled by the same module. It is a standard M.2 2230 slot with PCIe and USB interfaces (E-key).
 
 **Tools required:** Cross-head (Phillips) screwdriver  
 **Time estimate:** 12 minutes  

--- a/src/models/gaze15/repairs.md
+++ b/src/models/gaze15/repairs.md
@@ -212,7 +212,7 @@ The battery provides primary power whenever the system is unplugged.
 
 ## Replacing the wireless card:
 
-Your Gazelle's WiFi and Bluetooth are both handled by the same module. It is a standard M.2 2230 slot with PCIe and USB interfaces (A Key).
+Your Gazelle's WiFi and Bluetooth are both handled by the same module. It is a standard M.2 2230 slot with PCIe and USB interfaces (E-key).
 
 **Tools required:** Cross-head (Phillips) screwdriver  
 **Time estimate:** 10 minutes  

--- a/src/models/gaze16/repairs.md
+++ b/src/models/gaze16/repairs.md
@@ -94,7 +94,7 @@ This model supports up to two M.2 SSDs. Both M.2 slots are size 2280. The outer-
 
 ## Replacing the wireless card:
 
-Your Gazelle's WiFi and Bluetooth are both handled by the same module. It is a standard M.2 2230 slot with PCIe and USB interfaces (A Key).
+Your Gazelle's WiFi and Bluetooth are both handled by the same module. It is a standard M.2 2230 slot with PCIe and USB interfaces (E-key).
 
 **Tools required:** Cross-head (Phillips) screwdriver  
 **Time estimate:** 15 minutes  

--- a/src/models/gaze17/repairs.md
+++ b/src/models/gaze17/repairs.md
@@ -68,7 +68,7 @@ This model supports up to two M.2 SSDs. Both M.2 slots are size 2280. The inner-
 
 ## Replacing the wireless card:
 
-Your Gazelle's WiFi and Bluetooth are both handled by the same module. It is a standard M.2 2230 slot with PCIe and USB interfaces (A Key).
+Your Gazelle's WiFi and Bluetooth are both handled by the same module. It is a standard M.2 2230 slot with PCIe and USB interfaces (E-key).
 
 **Tools required:** Cross-head (Phillips) screwdriver  
 **Time estimate:** 15 minutes  

--- a/src/models/gaze18/repairs.md
+++ b/src/models/gaze18/repairs.md
@@ -69,7 +69,7 @@ This model supports up to two M.2 SSDs. Both M.2 slots are size 2280. The inner-
 
 ## Replacing the wireless card:
 
-Your Gazelle's WiFi and Bluetooth are both handled by the same module. It is a standard M.2 2230 slot with PCIe and USB interfaces (A Key).
+Your Gazelle's WiFi and Bluetooth are both handled by the same module. It is a standard M.2 2230 slot with PCIe and USB interfaces (E-key).
 
 **Tools required:** Cross-head (Phillips) screwdriver  
 **Time estimate:** 15 minutes  

--- a/src/models/kudu6/repairs.md
+++ b/src/models/kudu6/repairs.md
@@ -87,7 +87,7 @@ This model supports up to two M.2 SSDs. Both M.2 slots are size 2280, and both s
 
 ## Replacing the wireless card:
 
-Your Kudu's WiFi and Bluetooth are both handled by the same module. It is a standard M.2 2230 slot with PCIe and USB interfaces (A Key).
+Your Kudu's WiFi and Bluetooth are both handled by the same module. It is a standard M.2 2230 slot with PCIe and USB interfaces (E-key).
 
 **Tools required:** Cross-head (Phillips) screwdriver  
 **Time estimate:** 10 minutes  

--- a/src/models/lemp10/repairs.md
+++ b/src/models/lemp10/repairs.md
@@ -125,7 +125,7 @@ The CMOS battery supplies power to the system's CMOS chip. UEFI settings and the
 
 ## Replacing the wireless card:
 
-Your system's WiFi and Bluetooth are both handled by the same module. It connects with a standard M.2 2230 slot with PCIe and USB interfaces (A Key).
+Your system's WiFi and Bluetooth are both handled by the same module. It connects with a standard M.2 2230 slot with PCIe and USB interfaces (E-key).
 
 **Tools required:** Cross-head (Phillips) screwdriver    
 **Time estimate:** 10 minutes    

--- a/src/models/lemp11/repairs.md
+++ b/src/models/lemp11/repairs.md
@@ -71,7 +71,7 @@ This model supports two M.2 SSDs. Both slots are size 2280. SSD-1 supports PCIe 
 
 ## Replacing the wireless card:
 
-Your system's WiFi and Bluetooth are both handled by the same module. It connects with a standard M.2 2230 slot with PCIe and USB interfaces (A Key).
+Your system's WiFi and Bluetooth are both handled by the same module. It connects with a standard M.2 2230 slot with PCIe and USB interfaces (E-key).
 
 **Tools required:** Cross-head (Phillips) screwdriver    
 **Time estimate:** 10 minutes    

--- a/src/models/lemp12/repairs.md
+++ b/src/models/lemp12/repairs.md
@@ -71,7 +71,7 @@ This model supports two M.2 SSDs. Both slots are size 2280. SSD-1 supports PCIe 
 
 ## Replacing the wireless card:
 
-Your system's WiFi and Bluetooth are both handled by the same module. It connects with a standard M.2 2230 slot with PCIe and USB interfaces (A Key).
+Your system's WiFi and Bluetooth are both handled by the same module. It connects with a standard M.2 2230 slot with PCIe and USB interfaces (E-key).
 
 **Tools required:** Cross-head (Phillips) screwdriver    
 **Time estimate:** 10 minutes    

--- a/src/models/lemp9/repairs.md
+++ b/src/models/lemp9/repairs.md
@@ -119,7 +119,7 @@ The CMOS battery supplies power to the system's CMOS chip. UEFI settings and the
 
 ## Replacing the wireless card
 
-Your system's WiFi and Bluetooth are both handled by the same module. It connects with a standard M.2 2230 slot with PCIe and USB interfaces (A Key).
+Your system's WiFi and Bluetooth are both handled by the same module. It connects with a standard M.2 2230 slot with PCIe and USB interfaces (E-key).
 
 **Tools required:** Cross-head (Phillips) screwdriver    
 **Time estimate:** 10 minutes    

--- a/src/models/meer6/repairs.md
+++ b/src/models/meer6/repairs.md
@@ -117,7 +117,7 @@ A CMOS reset will restore the UEFI firmware settings to their factory defaults, 
 
 ## Replacing the wireless card:
 
-Your Meerkat's WiFi and Bluetooth are both handled by the same module. It is a standard M.2 2230 slot with PCIe and USB interfaces (A Key).
+Your Meerkat's WiFi and Bluetooth are both handled by the same module. It is a standard M.2 2230 slot with PCIe and USB interfaces (E-key).
 
 **Tools required:** Cross-head (Phillips) screwdriver, 5.0 mm hex socket  
 **Time estimate:** 15 minutes  

--- a/src/models/oryp10/repairs.md
+++ b/src/models/oryp10/repairs.md
@@ -90,7 +90,7 @@ The battery provides primary power whenever the system is unplugged.
 
 ## Replacing the wireless card:
 
-Your Oryx Pro's WiFi and Bluetooth are both handled by the same module. It is a standard M.2 2230 slot with PCIe and USB interfaces (A Key).
+Your Oryx Pro's WiFi and Bluetooth are both handled by the same module. It is a standard M.2 2230 slot with PCIe and USB interfaces (E-key).
 
 **Tools required:** Cross-head (Phillips) screwdriver  
 **Time estimate:** 10 minutes  

--- a/src/models/oryp11/repairs.md
+++ b/src/models/oryp11/repairs.md
@@ -92,7 +92,7 @@ The battery provides primary power whenever the system is unplugged. The model n
 
 ## Replacing the wireless card:
 
-Your Oryx Pro's WiFi and Bluetooth are both handled by the same module. It is a standard M.2 2230 slot with PCIe and USB interfaces (A Key).
+Your Oryx Pro's WiFi and Bluetooth are both handled by the same module. It is a standard M.2 2230 slot with PCIe and USB interfaces (E-key).
 
 **Tools required:** Cross-head (Phillips) screwdriver  
 **Time estimate:** 10 minutes  

--- a/src/models/oryp6/repairs.md
+++ b/src/models/oryp6/repairs.md
@@ -185,7 +185,7 @@ The CMOS battery supplies power to the system's CMOS chip. UEFI settings and the
 
 ## Replacing the wireless card:
 
-Your Oryx Pro's WiFi and Bluetooth are both handled by the same module. It is a standard M.2 2230 slot with PCIe and USB interfaces (A Key).
+Your Oryx Pro's WiFi and Bluetooth are both handled by the same module. It is a standard M.2 2230 slot with PCIe and USB interfaces (E-key).
 
 **Tools required:** Cross-head (Phillips) screwdriver  
 **Time estimate:** 10 minutes  

--- a/src/models/oryp7/repairs.md
+++ b/src/models/oryp7/repairs.md
@@ -70,7 +70,7 @@ This model supports up to two M.2 SSDs. Both M.2 slots are size 2280. The inner-
 
 ## Replacing the wireless card:
 
-Your Oryx Pro's WiFi and Bluetooth are both handled by the same module. It is a standard M.2 2230 slot with PCIe and USB interfaces (A Key).
+Your Oryx Pro's WiFi and Bluetooth are both handled by the same module. It is a standard M.2 2230 slot with PCIe and USB interfaces (E-key).
 
 **Tools required:** Cross-head (Phillips) screwdriver  
 **Time estimate:** 10 minutes  

--- a/src/models/oryp8/repairs.md
+++ b/src/models/oryp8/repairs.md
@@ -70,7 +70,7 @@ This model supports up to two M.2 SSDs. Both M.2 slots are size 2280. The inner-
 
 ## Replacing the wireless card:
 
-Your Oryx Pro's WiFi and Bluetooth are both handled by the same module. It is a standard M.2 2230 slot with PCIe and USB interfaces (A Key).
+Your Oryx Pro's WiFi and Bluetooth are both handled by the same module. It is a standard M.2 2230 slot with PCIe and USB interfaces (E-key).
 
 **Tools required:** Cross-head (Phillips) screwdriver  
 **Time estimate:** 10 minutes  

--- a/src/models/oryp9/repairs.md
+++ b/src/models/oryp9/repairs.md
@@ -89,7 +89,7 @@ The battery provides primary power whenever the system is unplugged.
 
 ## Replacing the wireless card:
 
-Your Oryx Pro's WiFi and Bluetooth are both handled by the same module. It is a standard M.2 2230 slot with PCIe and USB interfaces (A Key).
+Your Oryx Pro's WiFi and Bluetooth are both handled by the same module. It is a standard M.2 2230 slot with PCIe and USB interfaces (E-key).
 
 **Tools required:** Cross-head (Phillips) screwdriver  
 **Time estimate:** 10 minutes  

--- a/src/models/pang10/repairs.md
+++ b/src/models/pang10/repairs.md
@@ -121,7 +121,7 @@ This model supports one M.2 SSD of size 2280, either SATA III or PCIe NVMe Gener
 
 ## Replacing the wireless card:
 
-Your Pangolin's WiFi and Bluetooth are both handled by the same module. It is a standard M.2 2230 slot with PCIe and USB interfaces (A Key).
+Your Pangolin's WiFi and Bluetooth are both handled by the same module. It is a standard M.2 2230 slot with PCIe and USB interfaces (E-key).
 
 **Tools required:** Cross-head (Phillips) screwdriver  
 **Time estimate:** 12 minutes  

--- a/src/models/pang11/repairs.md
+++ b/src/models/pang11/repairs.md
@@ -86,7 +86,7 @@ This model supports one M.2 SSD of size 2280, either SATA III or PCIe NVMe Gener
 
 ## Replacing the wireless card:
 
-Your Pangolin's WiFi and Bluetooth are both handled by the same module. It is a standard M.2 2230 slot with PCIe and USB interfaces (A Key).
+Your Pangolin's WiFi and Bluetooth are both handled by the same module. It is a standard M.2 2230 slot with PCIe and USB interfaces (E-key).
 
 **Tools required:** Cross-head (Phillips) screwdriver  
 **Time estimate:** 12 minutes  

--- a/src/models/pang12/repairs.md
+++ b/src/models/pang12/repairs.md
@@ -74,7 +74,7 @@ The battery provides primary power whenever the system is unplugged.
 
 ## Replacing the wireless card:
 
-Your Pangolin's WiFi and Bluetooth are both handled by the same module. It is a standard M.2 2230 slot with PCIe and USB interfaces (A Key).
+Your Pangolin's WiFi and Bluetooth are both handled by the same module. It is a standard M.2 2230 slot with PCIe and USB interfaces (E-key).
 
 **Tools required:** Cross-head (Phillips) screwdriver  
 **Time estimate:** 12 minutes  

--- a/src/models/pang13/repairs.md
+++ b/src/models/pang13/repairs.md
@@ -75,7 +75,7 @@ The battery provides primary power whenever the system is unplugged.
 
 ## Replacing the wireless card:
 
-Your Pangolin's WiFi and Bluetooth are both handled by the same module. It is a standard M.2 2230 slot with PCIe and USB interfaces (A Key).
+Your Pangolin's WiFi and Bluetooth are both handled by the same module. It is a standard M.2 2230 slot with PCIe and USB interfaces (E-key).
 
 **Tools required:** Cross-head (Phillips) screwdriver  
 **Time estimate:** 12 minutes  

--- a/src/models/serw12/repairs.md
+++ b/src/models/serw12/repairs.md
@@ -221,7 +221,7 @@ The CMOS battery supplies power to the system's CMOS chip. UEFI settings and the
 
 ## Replacing the wireless card:
 
-Your Serval WS's WiFi and Bluetooth are both handled by the same module. It is a standard M.2 2230 slot with PCIe and USB interfaces (A Key).
+Your Serval WS's WiFi and Bluetooth are both handled by the same module. It is a standard M.2 2230 slot with PCIe and USB interfaces (E-key).
 
 **Tools required:** Cross-head (Phillips) screwdriver  
 **Time estimate:** 10 minutes  

--- a/src/models/serw13/repairs.md
+++ b/src/models/serw13/repairs.md
@@ -164,7 +164,7 @@ Depending on your climate and the age of the machine, it may be necessary to app
 
 ## Replacing the wireless card:
 
-Your Serval WS's WiFi and Bluetooth are both handled by the same module. It is a standard M.2 2230 slot with PCIe and USB interfaces (A Key).
+Your Serval WS's WiFi and Bluetooth are both handled by the same module. It is a standard M.2 2230 slot with PCIe and USB interfaces (E-key).
 
 **Tools required:** Cross-head (Phillips) screwdriver  
 **Time estimate:** 10 minutes  


### PR DESCRIPTION
Fixes #119, see that issue for research and validation specific to each model.

We were listing the wireless card M.2 slot as being A-key, when it was actually E-key.

This error was still being held over from the nearly-prehistoric PDF service manuals (it's possible a much older product actually used A-key, but at least one of the PDF manuals incorrectly listed A-key instead of E-key as well, since some of the earlier Tech Docs sections were copied in from the later PDF manuals).