### PR TITLE
Remove stray Z's from the end of the top level readme

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -63,4 +63,3 @@ The source can be viewed [on GitHub](https://github.com/system76/tech-docs).
 - [Serval WS (serw12)](models/serw12/README.md)
 - [Thelio Major (thelio-major-b1/b2/r1/r2)](models/thelio-major-b1-b2-r1-r2/README.md)
 - [Thelio Mira (thelio-mira-r1.0)](models/thelio-mira-r1.0/README.md)
-zz


### PR DESCRIPTION
Spotted by @thomas-zimmerman 