### PR TITLE
bonw15 & serw13 (specs): Add new CPU & display options

### DIFF
--- a/src/models/bonw15/README.md
+++ b/src/models/bonw15/README.md
@@ -9,10 +9,11 @@
 The System76 Bonobo WS is a laptop with the following specifications:
 
 - CPU
-    - Supports Intel 13th Generation (Raptor Lake) CPUs
+    - Supports Intel 13th & 14th Generation (Raptor Lake) CPUs
+        - [Core i9-14900HX](https://ark.intel.com/content/www/us/en/ark/products/235995/intel-core-i9-processor-14900hx-36m-cache-up-to-5-80-ghz.html)
         - [Core i9-13900HX](https://ark.intel.com/content/www/us/en/ark/products/232171/intel-core-i913900hx-processor-36m-cache-up-to-5-40-ghz.html)
 - Chipset
-    - [Intel HM770 Express](https://www.intel.com/content/www/us/en/products/sku/232478/intel-hm770-chipset/specifications.html) <!-- Not yet listed on ARK -->
+    - [Intel HM770](https://www.intel.com/content/www/us/en/products/sku/232478/intel-hm770-chipset/specifications.html)
 - BIOS
     - GigaDevice GD25B256EYIGR flash chip
         - WSON-8 form factor
@@ -29,6 +30,8 @@ The System76 Bonobo WS is a laptop with the following specifications:
     - eDP display options:
         - 17.3" 3840x2160@144Hz LCD
             - LCD panel: BOE NE173QUM-NY1 (or equivalent)
+        - 17.3" 2560x1440@240Hz LCD
+            - LCD panel: BOE NE173QHM-NZ1 (or equivalent)
     - External video outputs:
         - 1x HDMI 2.1
         - 1x Mini DisplayPort 1.4

--- a/src/models/serw13/README.md
+++ b/src/models/serw13/README.md
@@ -9,10 +9,11 @@
 The System76 Serval WS is a laptop with the following specifications:
 
 - CPU
-    - Supports Intel 13th Generation (Raptor Lake) CPUs
+    - Supports Intel 13th & 14th Generation (Raptor Lake) CPUs
+        - [Core i9-14900HX](https://ark.intel.com/content/www/us/en/ark/products/235995/intel-core-i9-processor-14900hx-36m-cache-up-to-5-80-ghz.html)
         - [Core i9-13900HX](https://ark.intel.com/content/www/us/en/ark/products/232171/intel-core-i913900hx-processor-36m-cache-up-to-5-40-ghz.html)
 - Chipset
-    - Intel HM770
+    - [Intel HM770](https://www.intel.com/content/www/us/en/products/sku/232478/intel-hm770-chipset/specifications.html)
 - BIOS
     - GigaDevice GD25B256EYIGR
         - WSON-8 form factor
@@ -27,8 +28,10 @@ The System76 Serval WS is a laptop with the following specifications:
     - eDP display:
         - 15.6" 1920x1080@165Hz LCD
             - LCD panel: BOE NV156FHM-NY8 (or equivalent)
-        - 17.6" 3840x2160@144Hz
+        - 17.3" 3840x2160@144Hz
             - LCD panel: AUO B173ZAN03.0 (or equivalent)
+        - 17.3" 2560x1440@240Hz LCD
+            - LCD panel: BOE NE173QHM-NZ1 (or equivalent)
     - External video outputs:
         - 1x HDMI
         - 1x Mini DisplayPort 1.4


### PR DESCRIPTION
While editing the files, I also made the chipset listing more consistent and corrected a minor typo on the serw13's existing 4k@144Hz panel option. (The 700-series chipsets still aren't listed on ARK, just the main Intel website.)

Closes #226.