### PR TITLE
launch_heavy_1: Specify PCB revisions & ribbon orientation

### DIFF
--- a/src/models/launch_heavy_1/README.md
+++ b/src/models/launch_heavy_1/README.md
@@ -11,7 +11,10 @@ The System76 Launch Heavy is a configurable keyboard with the following specific
   - [Open-source milled chassis design](https://github.com/system76/launch/tree/master/chassis/launch-heavy)
   - Dual magnetically-attachable 15-degree angle lift bars
 - Electronics
-  - [Open-source PCB design](https://github.com/system76/launch/tree/master/pcb-heavy)
+  - [Open-source main PCB design](https://github.com/system76/launch/tree/master/pcb)
+      - Revision 2.0
+  - [Open-source numpad PCB design](https://github.com/system76/launch/tree/master/pcb-heavy)
+      - Revision 1.1
   - Individually addressable RGB LED backlighting
   - N-key rollover
 - Sockets and Switches

--- a/src/models/launch_heavy_1/repairs.md
+++ b/src/models/launch_heavy_1/repairs.md
@@ -169,6 +169,7 @@ If either of the PCBs in your Launch Heavy become damaged and need to be replace
 
 4. Repeat the previous step for the numpad PCB.
 5. Insert the ribbon cable into the white connector on both PCBs, then slide the black latches shut.
+    - The ribbon should bend downwards from the connectors, so as not to obstruct the screw hole in the numpad PCB.
 6. Install the bottom cover and its four screws, flip the keyboard over, and put all of the keycaps back on.
     - If any of the oval steel inserts came loose from the bottom cover, put them back into place before reinstalling the bottom cover.
         - The steel inserts are held in with glue, but are also held in place magnetically if the magnetic lift bar is installed. They can be re-glued with CA glue.


### PR DESCRIPTION
This was intended to be part of commit ff56584709e55328dcfa4747bd75b33e4e087b31 in https://github.com/system76/tech-docs/pull/231, but it looks like I didn't check the files in before updating the commit message.

This adds the PCB revisions for Launch Heavy 1 and notes the orientation of the ribbon cable during its reinstallation.