### PR TITLE
Fix nebula49 to match the nebula36/19

### DIFF
--- a/src/models/nebula49-1/README.md
+++ b/src/models/nebula49-1/README.md
@@ -5,7 +5,7 @@
 
 ![nebula49](./img/nebula49-1.webp)
 
-The System76 Nebula 49 is a desktop chassis (for DIY builds) with the following specifications:
+The System76 nebula49 is a desktop chassis (for DIY builds) with the following specifications:
 
 - Dimensions
     - Size: 46.2cm × 26.2cm × 40.8cm


### PR DESCRIPTION
The nebula19 and nebula36 are spelled like that in the README but the nebula49 said Nebula 49 instead. This is to make them all match. 