### PR TITLE
gaze17 (specs): Correct Mini DisplayPort version

### DIFF
--- a/src/models/gaze17/README.md
+++ b/src/models/gaze17/README.md
@@ -38,11 +38,11 @@ The System76 Gazelle is a laptop with the following specifications:
     - External video output:
         - RTX 3060 model:
             - 1x HDMI
-            - 1x Mini DisplayPort 1.2
+            - 1x Mini DisplayPort 1.4
             - 1x DisplayPort 1.4 over USB-C
         - RTX 3050 Ti and 3050 models:
             - 1x HDMI
-            - 1x Mini DisplayPort 1.2
+            - 1x Mini DisplayPort 1.4
 - Memory
     - Up to 64GB (2x32GB) dual-channel DDR4 SO-DIMMs @ 3200 MHz
 - Networking


### PR DESCRIPTION
Confirmed in the upstream Clevo manuals that it's 1.4 for all variants, so the External Overview page was correct. This updates the specs on the first page to match.

NP50PNP (15" 3060):
![image](https://github.com/user-attachments/assets/19c3b5c9-5179-4256-88b4-f49d586f0f84)

NP70PNH/J/K (17" 3050 Ti/3050/1650):
![image](https://github.com/user-attachments/assets/27a89b90-846b-44f1-a08e-cb62e2e93cb1)