### PR TITLE
Do not keep gh-pages history

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,4 +29,5 @@ jobs:
           personal_token: ${{ secrets.RELEASE_TOKEN }}
           publish_branch: gh-pages
           publish_dir: ./book
+          force_orphan: true
           cname: 'tech-docs.system76.com'


### PR DESCRIPTION
Keeping the history of gh-pages adds a lot of bloat when trying to clone the repository. The force_orphan option added pushes just one commit with no prior history to the gh-pages branch on every change, which should significantly reduce the size of the repository.