### PR TITLE
serw13: Add version of HDMI port

### DIFF
--- a/src/models/serw13/README.md
+++ b/src/models/serw13/README.md
@@ -33,7 +33,7 @@ The System76 Serval WS is a laptop with the following specifications:
         - 15.6" 1920x1080@165Hz LCD
             - LCD panel: BOE NV156FHM-NY8 (or equivalent)
     - External video outputs:
-        - 1x HDMI
+        - 1x HDMI 2.1a
         - 1x Mini DisplayPort 1.4
         - 1x DisplayPort 1.4 over USB-C
 - Memory


### PR DESCRIPTION
This information is not in the upstream Clevo service manual, but confirmed with our hardware team that it matches what NVIDIA lists for the GPU, which is 2.1a.