### PR TITLE
thelio-r3-n1: Update maximum memory capacity & frequency

### DIFF
--- a/src/models/thelio-r3-n1/README.md
+++ b/src/models/thelio-r3-n1/README.md
@@ -38,7 +38,7 @@ The System76 Thelio is a desktop with the following specifications:
 - Expansion
     - 1x PCIe 4.0 x16 (GPU slot)
 - Memory
-    - Up to 64GB (2x32GB) dual-channel DDR5 DIMMs @ 4800 MHz
+    - Up to 128GB (2x64GB) dual-channel DDR5 DIMMs @ 4800 MHz (JEDEC) or 7200+ MHz (OC)
     - Tested with the following RAM modules (may ship with other tested modules):
         - [Crucial CT32G48C40U5](https://www.crucial.com/memory/ddr5/ct32g48c40u5#spec) (32GB/stick)
 - Networking


### PR DESCRIPTION
- Reference: https://www.msi.com/Motherboard/MPG-B650I-EDGE-WIFI/Specification

> Memory: 2x DDR5, Maximum Memory Capacity 128GB
Memory Support DDR5 7200+(OC)/ 7000(OC)/ 6800(OC)/ 6600(OC)/ 6400(OC)/ 6200(OC)/ 6000(OC)/ 5800(OC)/ 5600(OC)/ 5400(OC)/ 5200(OC)/ 5000(OC)/ 4800(JEDEC) MHz