### PR TITLE
copy specs from Mira as it is the same chassis

### DIFF
--- a/src/models/thelio-astra-a1-n1/README.md
+++ b/src/models/thelio-astra-a1-n1/README.md
@@ -93,3 +93,5 @@ The System76 Thelio Astra is a desktop with the following specifications:
 - USB
     - Back ports:
         - 4x USB 3.2 Gen 1 (Type-A)
+- Dimensions
+    - 43.8cm × 24.7cm × 37.2cm


### PR DESCRIPTION
I talked to production and the specs are the same for Astra, Mira, and Spark. 

This fixes issue https://github.com/system76/tech-docs/issues/275