### PR TITLE
Add Reese's Law small battery warning to all sections

### DIFF
--- a/src/models/addw1/repairs.md
+++ b/src/models/addw1/repairs.md
@@ -179,6 +179,8 @@ In rare cases, or after several years, it may be necessary to apply new thermal 
 
 The CMOS battery supplies power to the Adder WS's CMOS chip. Changes you make to the BIOS and the computer's hardware clock are stored on the CMOS. If your Adder WS doesn't boot, you can reset the CMOS to force a low-level hardware reset. If your clock is constantly resetting, it's likely your CMOS battery needs replacing.
 
+**Warning (ingestion hazard):** Keep batteries out of reach of children. Death or serious injury can occur if ingested. If a battery is suspected to be swallowed or inserted inside any part of the body, seek immediate medical attention. In the US, you can also call the National Battery Ingestion Hotline for guidance: [1 (800) 498-8666](tel:18004988666)
+
 **Tools required:** Cross-head (Phillips) screwdriver    
 **Time estimate:** 5 minutes    
 **Difficulty:** Medium <span style="color:orange;">●</span> 

--- a/src/models/addw2/repairs.md
+++ b/src/models/addw2/repairs.md
@@ -180,6 +180,8 @@ Your Adder WS's WiFi and Bluetooth are both handled by the same module. It is a 
 
 The CMOS battery supplies power to the system's CMOS chip. UEFI settings and the computer's hardware clock are stored on the CMOS. If your system doesn't boot, you can reset the CMOS to force a low-level hardware reset. If your clock is constantly resetting, it's likely your CMOS battery needs to be replaced.
 
+**Warning (ingestion hazard):** Keep batteries out of reach of children. Death or serious injury can occur if ingested. If a battery is suspected to be swallowed or inserted inside any part of the body, seek immediate medical attention. In the US, you can also call the National Battery Ingestion Hotline for guidance: [1 (800) 498-8666](tel:18004988666)
+
 **Tools required:** Cross-head (Phillips) screwdriver    
 **Time estimate:** 15 minutes    
 **Difficulty:** Medium <span style="color:orange;">●</span>

--- a/src/models/addw3/repairs.md
+++ b/src/models/addw3/repairs.md
@@ -115,6 +115,8 @@ Your Adder WS's WiFi and Bluetooth are both handled by the same module. It is a 
 
 The CMOS battery supplies power to the system's CMOS chip. UEFI settings and the computer's hardware clock are stored on the CMOS. If your system doesn't boot, you can reset the CMOS to force a low-level hardware reset. If your clock is constantly resetting, it's likely your CMOS battery needs to be replaced.
 
+**Warning (ingestion hazard):** Keep batteries out of reach of children. Death or serious injury can occur if ingested. If a battery is suspected to be swallowed or inserted inside any part of the body, seek immediate medical attention. In the US, you can also call the National Battery Ingestion Hotline for guidance: [1 (800) 498-8666](tel:18004988666)
+
 **Tools required:** Cross-head (Phillips) screwdriver    
 **Time estimate:** 15 minutes    
 **Difficulty:** Medium <span style="color:orange;">●</span>

--- a/src/models/addw4/repairs.md
+++ b/src/models/addw4/repairs.md
@@ -98,6 +98,8 @@ The battery provides primary power whenever the system is unplugged.
 
 The CMOS battery supplies power to the system's CMOS chip. UEFI settings and the computer's hardware clock are stored on the CMOS. If your system doesn't boot, you can reset the CMOS to force a low-level hardware reset. If your clock is constantly resetting, it's likely your CMOS battery needs to be replaced.
 
+**Warning (ingestion hazard):** Keep batteries out of reach of children. Death or serious injury can occur if ingested. If a battery is suspected to be swallowed or inserted inside any part of the body, seek immediate medical attention. In the US, you can also call the National Battery Ingestion Hotline for guidance: [1 (800) 498-8666](tel:18004988666)
+
 **Part numbers:**
 - The CMOS battery is a standard 3V 3Y3 CR2032W battery.
 

--- a/src/models/bonw14/repairs.md
+++ b/src/models/bonw14/repairs.md
@@ -159,6 +159,8 @@ Your Bonobo WS's WiFi and Bluetooth are both handled by the same module. It is a
 
 The CMOS battery supplies power to the system's CMOS chip. UEFI settings and the computer's hardware clock are stored on the CMOS. If your system doesn't boot, you can reset the CMOS to force a low-level hardware reset. If your clock is constantly resetting, it's likely your CMOS battery needs to be replaced.
 
+**Warning (ingestion hazard):** Keep batteries out of reach of children. Death or serious injury can occur if ingested. If a battery is suspected to be swallowed or inserted inside any part of the body, seek immediate medical attention. In the US, you can also call the National Battery Ingestion Hotline for guidance: [1 (800) 498-8666](tel:18004988666)
+
 **Tools required:** Cross-head (Phillips) screwdriver    
 **Time estimate:** 10 minutes    
 **Difficulty:** Easy <span style="color:green;">●</span>

--- a/src/models/bonw15/repairs.md
+++ b/src/models/bonw15/repairs.md
@@ -119,6 +119,8 @@ Your Bonobo WS's WiFi and Bluetooth are both handled by the same module. It is a
 
 The CMOS battery supplies power to the system's CMOS chip. UEFI settings and the comptuer's hardware clock are stored on the CMOS. If your system doesn't boot, you can reset the CMOS to force a low-level hardware reset. If your clock is constantly resetting, it's likely your CMOS battery needs to be replaced.
 
+**Warning (ingestion hazard):** Keep batteries out of reach of children. Death or serious injury can occur if ingested. If a battery is suspected to be swallowed or inserted inside any part of the body, seek immediate medical attention. In the US, you can also call the National Battery Ingestion Hotline for guidance: [1 (800) 498-8666](tel:18004988666)
+
 **Tools required:** Cross-head (Phillips) screwdriver    
 **Time estimate:** 10 minutes    
 **Difficulty:** Easy <span style="color:green;">●</span>

--- a/src/models/darp10/repairs.md
+++ b/src/models/darp10/repairs.md
@@ -112,6 +112,8 @@ Your Darter Pro's WiFi and Bluetooth are both handled by the same module. It is 
 
 The CMOS battery supplies power to the system's CMOS chip. UEFI settings and the computer's hardware clock are stored on the CMOS. If your system doesn't boot, you can reset the CMOS to force a low-level hardware reset. If your clock is constantly resetting, it's likely your CMOS battery needs to be replaced.
 
+**Warning (ingestion hazard):** Keep batteries out of reach of children. Death or serious injury can occur if ingested. If a battery is suspected to be swallowed or inserted inside any part of the body, seek immediate medical attention. In the US, you can also call the National Battery Ingestion Hotline for guidance: [1 (800) 498-8666](tel:18004988666)
+
 **Part numbers:**
 - The CMOS battery is a standard 3V KTS CR2032W battery.
 

--- a/src/models/darp6/repairs.md
+++ b/src/models/darp6/repairs.md
@@ -153,6 +153,8 @@ Your Darter Pro's WiFi and Bluetooth are both handled by the same module. It is 
 
 The CMOS battery supplies power to the system's CMOS chip. UEFI settings and the computer's hardware clock are stored on the CMOS. If your system doesn't boot, you can reset the CMOS to force a low-level hardware reset. If your clock is constantly resetting, it's likely your CMOS battery needs to be replaced.
 
+**Warning (ingestion hazard):** Keep batteries out of reach of children. Death or serious injury can occur if ingested. If a battery is suspected to be swallowed or inserted inside any part of the body, seek immediate medical attention. In the US, you can also call the National Battery Ingestion Hotline for guidance: [1 (800) 498-8666](tel:18004988666)
+
 **Tools required:** Cross-head (Phillips) screwdriver    
 **Time estimate:** 10 minutes    
 **Difficulty:** Easy <span style="color:green;">●</span>

--- a/src/models/darp7/repairs.md
+++ b/src/models/darp7/repairs.md
@@ -98,6 +98,8 @@ Your Darter Pro's WiFi and Bluetooth are both handled by the same module. It is 
 
 The CMOS battery supplies power to the system's CMOS chip. UEFI settings and the computer's hardware clock are stored on the CMOS. If your system doesn't boot, you can reset the CMOS to force a low-level hardware reset. If your clock is constantly resetting, it's likely your CMOS battery needs to be replaced.
 
+**Warning (ingestion hazard):** Keep batteries out of reach of children. Death or serious injury can occur if ingested. If a battery is suspected to be swallowed or inserted inside any part of the body, seek immediate medical attention. In the US, you can also call the National Battery Ingestion Hotline for guidance: [1 (800) 498-8666](tel:18004988666)
+
 **Tools required:** Cross-head (Phillips) screwdriver    
 **Time estimate:** 12 minutes    
 **Difficulty:** Easy <span style="color:green;">●</span>

--- a/src/models/darp8/repairs.md
+++ b/src/models/darp8/repairs.md
@@ -98,6 +98,8 @@ Your Darter Pro's WiFi and Bluetooth are both handled by the same module. It is 
 
 The CMOS battery supplies power to the system's CMOS chip. UEFI settings and the computer's hardware clock are stored on the CMOS. If your system doesn't boot, you can reset the CMOS to force a low-level hardware reset. If your clock is constantly resetting, it's likely your CMOS battery needs to be replaced.
 
+**Warning (ingestion hazard):** Keep batteries out of reach of children. Death or serious injury can occur if ingested. If a battery is suspected to be swallowed or inserted inside any part of the body, seek immediate medical attention. In the US, you can also call the National Battery Ingestion Hotline for guidance: [1 (800) 498-8666](tel:18004988666)
+
 **Tools required:** Cross-head (Phillips) screwdriver    
 **Time estimate:** 12 minutes    
 **Difficulty:** Easy <span style="color:green;">●</span>

--- a/src/models/darp9/repairs.md
+++ b/src/models/darp9/repairs.md
@@ -99,6 +99,8 @@ Your Darter Pro's WiFi and Bluetooth are both handled by the same module. It is 
 
 The CMOS battery supplies power to the system's CMOS chip. UEFI settings and the computer's hardware clock are stored on the CMOS. If your system doesn't boot, you can reset the CMOS to force a low-level hardware reset. If your clock is constantly resetting, it's likely your CMOS battery needs to be replaced.
 
+**Warning (ingestion hazard):** Keep batteries out of reach of children. Death or serious injury can occur if ingested. If a battery is suspected to be swallowed or inserted inside any part of the body, seek immediate medical attention. In the US, you can also call the National Battery Ingestion Hotline for guidance: [1 (800) 498-8666](tel:18004988666)
+
 **Tools required:** Cross-head (Phillips) screwdriver    
 **Time estimate:** 12 minutes    
 **Difficulty:** Easy <span style="color:green;">●</span>

--- a/src/models/galp4/repairs.md
+++ b/src/models/galp4/repairs.md
@@ -172,6 +172,8 @@ Your Galago Pro's WiFi and Bluetooth are both handled by the same module. It is 
 
 The CMOS battery supplies power to the system's CMOS chip. UEFI settings and the computer's hardware clock are stored on the CMOS. If your system doesn't boot, you can reset the CMOS to force a low-level hardware reset. If your clock is constantly resetting, it's likely your CMOS battery needs to be replaced.
 
+**Warning (ingestion hazard):** Keep batteries out of reach of children. Death or serious injury can occur if ingested. If a battery is suspected to be swallowed or inserted inside any part of the body, seek immediate medical attention. In the US, you can also call the National Battery Ingestion Hotline for guidance: [1 (800) 498-8666](tel:18004988666)
+
 **Tools required:** Cross-head (Phillips) screwdriver    
 **Time estimate:** 10 minutes    
 **Difficulty:** Easy <span style="color:green;">●</span>

--- a/src/models/galp5/repairs.md
+++ b/src/models/galp5/repairs.md
@@ -112,6 +112,8 @@ Your Galago Pro's WiFi and Bluetooth are both handled by the same module. It is 
 
 The CMOS battery supplies power to the system's CMOS chip. UEFI settings and the computer's hardware clock are stored on the CMOS. If your system doesn't boot, you can reset the CMOS to force a low-level hardware reset. If your clock is constantly resetting, it's likely your CMOS battery needs to be replaced.
 
+**Warning (ingestion hazard):** Keep batteries out of reach of children. Death or serious injury can occur if ingested. If a battery is suspected to be swallowed or inserted inside any part of the body, seek immediate medical attention. In the US, you can also call the National Battery Ingestion Hotline for guidance: [1 (800) 498-8666](tel:18004988666)
+
 **Tools required:** Cross-head (Phillips) screwdriver    
 **Time estimate:** 15 minutes    
 **Difficulty:** Medium <span style="color:orange;">●</span>

--- a/src/models/galp6/repairs.md
+++ b/src/models/galp6/repairs.md
@@ -113,6 +113,8 @@ Your Galago Pro's WiFi and Bluetooth are both handled by the same module. It is 
 
 The CMOS battery supplies power to the system's CMOS chip. UEFI settings and the computer's hardware clock are stored on the CMOS. If your system doesn't boot, you can reset the CMOS to force a low-level hardware reset. If your clock is constantly resetting, it's likely your CMOS battery needs to be replaced.
 
+**Warning (ingestion hazard):** Keep batteries out of reach of children. Death or serious injury can occur if ingested. If a battery is suspected to be swallowed or inserted inside any part of the body, seek immediate medical attention. In the US, you can also call the National Battery Ingestion Hotline for guidance: [1 (800) 498-8666](tel:18004988666)
+
 **Tools required:** Cross-head (Phillips) screwdriver    
 **Time estimate:** 15 minutes    
 **Difficulty:** Medium <span style="color:orange;">●</span>

--- a/src/models/galp7/repairs.md
+++ b/src/models/galp7/repairs.md
@@ -113,6 +113,8 @@ Your Galago Pro's WiFi and Bluetooth are both handled by the same module. It is 
 
 The CMOS battery supplies power to the system's CMOS chip. UEFI settings and the computer's hardware clock are stored on the CMOS. If your system doesn't boot, you can reset the CMOS to force a low-level hardware reset. If your clock is constantly resetting, it's likely your CMOS battery needs to be replaced.
 
+**Warning (ingestion hazard):** Keep batteries out of reach of children. Death or serious injury can occur if ingested. If a battery is suspected to be swallowed or inserted inside any part of the body, seek immediate medical attention. In the US, you can also call the National Battery Ingestion Hotline for guidance: [1 (800) 498-8666](tel:18004988666)
+
 **Tools required:** Cross-head (Phillips) screwdriver    
 **Time estimate:** 15 minutes    
 **Difficulty:** Medium <span style="color:orange;">●</span>

--- a/src/models/gaze15/repairs.md
+++ b/src/models/gaze15/repairs.md
@@ -178,6 +178,8 @@ Depending on your climate and the age of the machine, it may be necessary to app
 
 The CMOS battery supplies power to the Gazelle's CMOS chip. Changes you make to the UEFI firmware settings and the computer's hardware clock are stored on the CMOS. If your Gazelle doesn't boot, you can reset the CMOS to force a low-level hardware reset. If your clock is constantly resetting, it's likely your CMOS battery needs replacing.
 
+**Warning (ingestion hazard):** Keep batteries out of reach of children. Death or serious injury can occur if ingested. If a battery is suspected to be swallowed or inserted inside any part of the body, seek immediate medical attention. In the US, you can also call the National Battery Ingestion Hotline for guidance: [1 (800) 498-8666](tel:18004988666)
+
 **Tools required:** Cross-head (Phillips) screwdriver  
 **Time estimate:** 10 minutes  
 **Difficulty:** Medium <span style="color:orange;">●</span>  

--- a/src/models/gaze16/repairs.md
+++ b/src/models/gaze16/repairs.md
@@ -120,6 +120,8 @@ Your Gazelle's WiFi and Bluetooth are both handled by the same module. It is a s
 
 The CMOS battery supplies power to the system's CMOS chip. UEFI settings and the computer's hardware clock are stored on the CMOS. If your system doesn't boot, you can reset the CMOS to force a low-level hardware reset. If your clock is constantly resetting, it's likely your CMOS battery needs to be replaced.
 
+**Warning (ingestion hazard):** Keep batteries out of reach of children. Death or serious injury can occur if ingested. If a battery is suspected to be swallowed or inserted inside any part of the body, seek immediate medical attention. In the US, you can also call the National Battery Ingestion Hotline for guidance: [1 (800) 498-8666](tel:18004988666)
+
 **Tools required:** Cross-head (Phillips) screwdriver    
 **Time estimate:** 15 minutes    
 **Difficulty:** Medium <span style="color:orange;">●</span>

--- a/src/models/gaze17/repairs.md
+++ b/src/models/gaze17/repairs.md
@@ -111,6 +111,8 @@ The model number for the Gazelle 17's battery is `NP50BAT-4-54`, and the origina
 
 The CMOS battery supplies power to the system's CMOS chip. UEFI settings and the computer's hardware clock are stored on the CMOS. If your system doesn't boot, you can reset the CMOS to force a low-level hardware reset. If your clock is constantly resetting, it's likely your CMOS battery needs to be replaced.
 
+**Warning (ingestion hazard):** Keep batteries out of reach of children. Death or serious injury can occur if ingested. If a battery is suspected to be swallowed or inserted inside any part of the body, seek immediate medical attention. In the US, you can also call the National Battery Ingestion Hotline for guidance: [1 (800) 498-8666](tel:18004988666)
+
 **Tools required:** Cross-head (Phillips) screwdriver    
 **Time estimate:** 15 minutes    
 **Difficulty:** Medium <span style="color:orange;">●</span>

--- a/src/models/gaze18/repairs.md
+++ b/src/models/gaze18/repairs.md
@@ -112,6 +112,8 @@ The model number for the Gazelle 18's battery is `NP50BAT-4-54`, and the origina
 
 The CMOS battery supplies power to the system's CMOS chip. UEFI settings and the computer's hardware clock are stored on the CMOS. If your system doesn't boot, you can reset the CMOS to force a low-level hardware reset. If your clock is constantly resetting, it's likely your CMOS battery needs to be replaced.
 
+**Warning (ingestion hazard):** Keep batteries out of reach of children. Death or serious injury can occur if ingested. If a battery is suspected to be swallowed or inserted inside any part of the body, seek immediate medical attention. In the US, you can also call the National Battery Ingestion Hotline for guidance: [1 (800) 498-8666](tel:18004988666)
+
 **Tools required:** Cross-head (Phillips) screwdriver    
 **Time estimate:** 15 minutes    
 **Difficulty:** Medium <span style="color:orange;">●</span>

--- a/src/models/kudu6/repairs.md
+++ b/src/models/kudu6/repairs.md
@@ -113,6 +113,8 @@ Your Kudu's WiFi and Bluetooth are both handled by the same module. It is a stan
 
 The CMOS battery supplies power to the system's CMOS chip. UEFI settings and the computer's hardware clock are stored on the CMOS. If your system doesn't boot, you can reset the CMOS to force a low-level hardware reset. If your clock is constantly resetting, it's likely your CMOS battery needs to be replaced.
 
+**Warning (ingestion hazard):** Keep batteries out of reach of children. Death or serious injury can occur if ingested. If a battery is suspected to be swallowed or inserted inside any part of the body, seek immediate medical attention. In the US, you can also call the National Battery Ingestion Hotline for guidance: [1 (800) 498-8666](tel:18004988666)
+
 **Tools required:** Cross-head (Phillips) screwdriver    
 **Time estimate:** 15 minutes    
 **Difficulty:** Medium <span style="color:orange;">●</span>

--- a/src/models/lemp10/repairs.md
+++ b/src/models/lemp10/repairs.md
@@ -105,6 +105,8 @@ Depending on your climate and the age of the machine, it may be necessary to app
 
 The CMOS battery supplies power to the system's CMOS chip. UEFI settings and the computer's hardware clock are stored on the CMOS. If your system doesn't boot, you can reset the CMOS to force a low-level hardware reset. If your clock is constantly resetting, it's likely your CMOS battery needs replacing.
 
+**Warning (ingestion hazard):** Keep batteries out of reach of children. Death or serious injury can occur if ingested. If a battery is suspected to be swallowed or inserted inside any part of the body, seek immediate medical attention. In the US, you can also call the National Battery Ingestion Hotline for guidance: [1 (800) 498-8666](tel:18004988666)
+
 **Tools required:** Cross-head (Phillips) screwdriver    
 **Time estimate:** 10 minutes    
 **Difficulty:** Medium <span style="color:orange;">●</span>

--- a/src/models/lemp11/repairs.md
+++ b/src/models/lemp11/repairs.md
@@ -95,6 +95,8 @@ Your system's WiFi and Bluetooth are both handled by the same module. It connect
 
 The CMOS battery supplies power to the system's CMOS chip. UEFI settings and the computer's hardware clock are stored on the CMOS. If your system doesn't boot, you can reset the CMOS to force a low-level hardware reset. If your clock is constantly resetting, it's likely your CMOS battery needs to be replaced.
 
+**Warning (ingestion hazard):** Keep batteries out of reach of children. Death or serious injury can occur if ingested. If a battery is suspected to be swallowed or inserted inside any part of the body, seek immediate medical attention. In the US, you can also call the National Battery Ingestion Hotline for guidance: [1 (800) 498-8666](tel:18004988666)
+
 **Tools required:** Cross-head (Phillips) screwdriver    
 **Time estimate:** 10 minutes    
 **Difficulty:** Medium <span style="color:orange;">●</span>

--- a/src/models/lemp12/repairs.md
+++ b/src/models/lemp12/repairs.md
@@ -95,6 +95,8 @@ Your system's WiFi and Bluetooth are both handled by the same module. It connect
 
 The CMOS battery supplies power to the system's CMOS chip. UEFI settings and the computer's hardware clock are stored on the CMOS. If your system doesn't boot, you can reset the CMOS to force a low-level hardware reset. If your clock is constantly resetting, it's likely your CMOS battery needs to be replaced.
 
+**Warning (ingestion hazard):** Keep batteries out of reach of children. Death or serious injury can occur if ingested. If a battery is suspected to be swallowed or inserted inside any part of the body, seek immediate medical attention. In the US, you can also call the National Battery Ingestion Hotline for guidance: [1 (800) 498-8666](tel:18004988666)
+
 **Tools required:** Cross-head (Phillips) screwdriver    
 **Time estimate:** 10 minutes    
 **Difficulty:** Medium <span style="color:orange;">●</span>

--- a/src/models/lemp13/repairs.md
+++ b/src/models/lemp13/repairs.md
@@ -128,6 +128,8 @@ The battery provides primary power whenever the system is unplugged.
 
 The CMOS battery supplies power to the system's CMOS chip. UEFI settings and the computer's hardware clock are stored on the CMOS. If your system doesn't boot, you can reset the CMOS to force a low-level hardware reset. If your clock is constantly resetting, it's likely your CMOS battery needs to be replaced.
 
+**Warning (ingestion hazard):** Keep batteries out of reach of children. Death or serious injury can occur if ingested. If a battery is suspected to be swallowed or inserted inside any part of the body, seek immediate medical attention. In the US, you can also call the National Battery Ingestion Hotline for guidance: [1 (800) 498-8666](tel:18004988666)
+
 **Part numbers:**
 
 - The CMOS battery is a standard 3V KTS CR2032W battery.

--- a/src/models/lemp9/repairs.md
+++ b/src/models/lemp9/repairs.md
@@ -101,6 +101,8 @@ Depending on your climate and the age of the machine, it may be necessary to app
 
 The CMOS battery supplies power to the system's CMOS chip. UEFI settings and the computer's hardware clock are stored on the CMOS. If your system doesn't boot, you can reset the CMOS to force a low-level hardware reset. If your clock is constantly resetting, it's likely your CMOS battery needs replacing.
 
+**Warning (ingestion hazard):** Keep batteries out of reach of children. Death or serious injury can occur if ingested. If a battery is suspected to be swallowed or inserted inside any part of the body, seek immediate medical attention. In the US, you can also call the National Battery Ingestion Hotline for guidance: [1 (800) 498-8666](tel:18004988666)
+
 **Tools required:** Cross-head (Phillips) screwdriver    
 **Time estimate:** 10 minutes    
 **Difficulty:** Medium <span style="color:orange;">●</span>

--- a/src/models/meer5/repairs.md
+++ b/src/models/meer5/repairs.md
@@ -104,6 +104,8 @@ If your Meerkat is the tall variety, it has a 2.5" drive bay built into the bott
 
 Sometimes resetting CMOS can help if your Meerkat is not booting. A CMOS reset will restore BIOS settings to their factory defaults, so you may have to reconfigure your BIOS afterwards.
 
+**Warning (ingestion hazard):** Keep batteries out of reach of children. Death or serious injury can occur if ingested. If a battery is suspected to be swallowed or inserted inside any part of the body, seek immediate medical attention. In the US, you can also call the National Battery Ingestion Hotline for guidance: [1 (800) 498-8666](tel:18004988666)
+
 **Tools required:** Cross-head (Phillips) screwdriver and (optionally) tweezers  
 **Time estimate:** 15 minutes  
 **Difficulty:** Medium <span style="color:orange;">●</span>  

--- a/src/models/meer6/repairs.md
+++ b/src/models/meer6/repairs.md
@@ -184,6 +184,8 @@ The cooling fan can be removed to clean dust out of the cooling system or to acc
 
 The CMOS battery supplies power to the system's CMOS chip, where UEFI settings and the computer's hardware clock are stored. If your clock is constantly resetting, your CMOS battery may need to be replaced.
 
+**Warning (ingestion hazard):** Keep batteries out of reach of children. Death or serious injury can occur if ingested. If a battery is suspected to be swallowed or inserted inside any part of the body, seek immediate medical attention. In the US, you can also call the National Battery Ingestion Hotline for guidance: [1 (800) 498-8666](tel:18004988666)
+
 **Tools required:** Cross-head (Phillips) screwdriver  
 **Time estimate:** 27 minutes  
 **Difficulty:** High <span style="color:red;">●</span>  

--- a/src/models/meer7/repairs.md
+++ b/src/models/meer7/repairs.md
@@ -239,6 +239,8 @@ The screws used for the fan are the same type as those used for the [M.2 SSDs](#
 
 The CMOS battery supplies power to the system's CMOS chip, where UEFI settings and the computer's hardware clock are stored. If your clock is constantly resetting, your CMOS battery may need to be replaced.
 
+**Warning (ingestion hazard):** Keep batteries out of reach of children. Death or serious injury can occur if ingested. If a battery is suspected to be swallowed or inserted inside any part of the body, seek immediate medical attention. In the US, you can also call the National Battery Ingestion Hotline for guidance: [1 (800) 498-8666](tel:18004988666)
+
 **Tools required:** Cross-head (Phillips) screwdriver  
 **Time estimate:** 27 minutes  
 **Difficulty:** High <span style="color:red;">●</span>  

--- a/src/models/meer8/repairs.md
+++ b/src/models/meer8/repairs.md
@@ -239,6 +239,8 @@ The fan is an AVC `BAZC0810R5HY006`. The screws used for the fan are the same ty
 
 The CMOS battery supplies power to the system's CMOS chip, where UEFI settings and the computer's hardware clock are stored. If your clock is constantly resetting, your CMOS battery may need to be replaced.
 
+**Warning (ingestion hazard):** Keep batteries out of reach of children. Death or serious injury can occur if ingested. If a battery is suspected to be swallowed or inserted inside any part of the body, seek immediate medical attention. In the US, you can also call the National Battery Ingestion Hotline for guidance: [1 (800) 498-8666](tel:18004988666)
+
 **Tools required:** Cross-head (Phillips) screwdriver  
 **Time estimate:** 27 minutes  
 **Difficulty:** High <span style="color:red;">●</span>  

--- a/src/models/oryp10/repairs.md
+++ b/src/models/oryp10/repairs.md
@@ -122,6 +122,8 @@ Your Oryx Pro's WiFi and Bluetooth are both handled by the same module. It is a 
 
 The CMOS battery supplies power to the system's CMOS chip. UEFI settings and the computer's hardware clock are stored on the CMOS. If your system doesn't boot, you can reset the CMOS to force a low-level hardware reset. If your clock is constantly resetting, it's likely your CMOS battery needs to be replaced.
 
+**Warning (ingestion hazard):** Keep batteries out of reach of children. Death or serious injury can occur if ingested. If a battery is suspected to be swallowed or inserted inside any part of the body, seek immediate medical attention. In the US, you can also call the National Battery Ingestion Hotline for guidance: [1 (800) 498-8666](tel:18004988666)
+
 **Tools required:** Cross-head (Phillips) screwdriver    
 **Time estimate:** 15 minutes    
 **Difficulty:** Medium <span style="color:orange;">●</span>

--- a/src/models/oryp11/repairs.md
+++ b/src/models/oryp11/repairs.md
@@ -118,6 +118,8 @@ Your Oryx Pro's WiFi and Bluetooth are both handled by the same module. It is a 
 
 The CMOS battery supplies power to the system's CMOS chip. UEFI settings and the computer's hardware clock are stored on the CMOS. If your system doesn't boot, you can reset the CMOS to force a low-level hardware reset. If your clock is constantly resetting, it's likely your CMOS battery needs to be replaced.
 
+**Warning (ingestion hazard):** Keep batteries out of reach of children. Death or serious injury can occur if ingested. If a battery is suspected to be swallowed or inserted inside any part of the body, seek immediate medical attention. In the US, you can also call the National Battery Ingestion Hotline for guidance: [1 (800) 498-8666](tel:18004988666)
+
 **Tools required:** Cross-head (Phillips) screwdriver    
 **Time estimate:** 15 minutes    
 **Difficulty:** Medium <span style="color:orange;">●</span>

--- a/src/models/oryp12/repairs.md
+++ b/src/models/oryp12/repairs.md
@@ -127,6 +127,8 @@ Your Oryx Pro's WiFi and Bluetooth are both handled by the same module. It is a 
 
 The CMOS battery supplies power to the system's CMOS chip. UEFI settings and the computer's hardware clock are stored on the CMOS. If your system doesn't boot, you can reset the CMOS to force a low-level hardware reset. If your clock is constantly resetting, it's likely your CMOS battery needs to be replaced.
 
+**Warning (ingestion hazard):** Keep batteries out of reach of children. Death or serious injury can occur if ingested. If a battery is suspected to be swallowed or inserted inside any part of the body, seek immediate medical attention. In the US, you can also call the National Battery Ingestion Hotline for guidance: [1 (800) 498-8666](tel:18004988666)
+
 **Part numbers:**
 - The CMOS battery is a standard 3V KTS CR2032W battery.
 

--- a/src/models/oryp6/repairs.md
+++ b/src/models/oryp6/repairs.md
@@ -168,6 +168,8 @@ The model number for the Oryx Pro 6's battery is `PC50BAT-3`, and the original p
 
 The CMOS battery supplies power to the system's CMOS chip. UEFI settings and the computer's hardware clock are stored on the CMOS. If your system doesn't boot, you can reset the CMOS to force a low-level hardware reset. If your clock is constantly resetting, it's likely your CMOS battery needs replacing.
 
+**Warning (ingestion hazard):** Keep batteries out of reach of children. Death or serious injury can occur if ingested. If a battery is suspected to be swallowed or inserted inside any part of the body, seek immediate medical attention. In the US, you can also call the National Battery Ingestion Hotline for guidance: [1 (800) 498-8666](tel:18004988666)
+
 **Tools required:** Cross-head (Phillips) screwdriver    
 **Time estimate:** 10 minutes    
 **Difficulty:** Medium <span style="color:orange;">●</span>

--- a/src/models/oryp7/repairs.md
+++ b/src/models/oryp7/repairs.md
@@ -116,6 +116,8 @@ The model number for the Oryx Pro 7's battery is `PC50BAT-3`, and the original p
 
 The CMOS battery supplies power to the system's CMOS chip. UEFI settings and the computer's hardware clock are stored on the CMOS. If your system doesn't boot, you can reset the CMOS to force a low-level hardware reset. If your clock is constantly resetting, it's likely your CMOS battery needs to be replaced.
 
+**Warning (ingestion hazard):** Keep batteries out of reach of children. Death or serious injury can occur if ingested. If a battery is suspected to be swallowed or inserted inside any part of the body, seek immediate medical attention. In the US, you can also call the National Battery Ingestion Hotline for guidance: [1 (800) 498-8666](tel:18004988666)
+
 **Tools required:** Cross-head (Phillips) screwdriver    
 **Time estimate:** 15 minutes    
 **Difficulty:** Medium <span style="color:orange;">●</span>

--- a/src/models/oryp8/repairs.md
+++ b/src/models/oryp8/repairs.md
@@ -116,6 +116,8 @@ The model number for the Oryx Pro 8's battery is `PC50BAT-3`, and the original p
 
 The CMOS battery supplies power to the system's CMOS chip. UEFI settings and the computer's hardware clock are stored on the CMOS. If your system doesn't boot, you can reset the CMOS to force a low-level hardware reset. If your clock is constantly resetting, it's likely your CMOS battery needs to be replaced.
 
+**Warning (ingestion hazard):** Keep batteries out of reach of children. Death or serious injury can occur if ingested. If a battery is suspected to be swallowed or inserted inside any part of the body, seek immediate medical attention. In the US, you can also call the National Battery Ingestion Hotline for guidance: [1 (800) 498-8666](tel:18004988666)
+
 **Tools required:** Cross-head (Phillips) screwdriver    
 **Time estimate:** 15 minutes    
 **Difficulty:** Medium <span style="color:orange;">●</span>

--- a/src/models/oryp9/repairs.md
+++ b/src/models/oryp9/repairs.md
@@ -121,6 +121,8 @@ Your Oryx Pro's WiFi and Bluetooth are both handled by the same module. It is a 
 
 The CMOS battery supplies power to the system's CMOS chip. UEFI settings and the computer's hardware clock are stored on the CMOS. If your system doesn't boot, you can reset the CMOS to force a low-level hardware reset. If your clock is constantly resetting, it's likely your CMOS battery needs to be replaced.
 
+**Warning (ingestion hazard):** Keep batteries out of reach of children. Death or serious injury can occur if ingested. If a battery is suspected to be swallowed or inserted inside any part of the body, seek immediate medical attention. In the US, you can also call the National Battery Ingestion Hotline for guidance: [1 (800) 498-8666](tel:18004988666)
+
 **Tools required:** Cross-head (Phillips) screwdriver    
 **Time estimate:** 15 minutes    
 **Difficulty:** Medium <span style="color:orange;">●</span>

--- a/src/models/pang10/repairs.md
+++ b/src/models/pang10/repairs.md
@@ -147,6 +147,8 @@ Your Pangolin's WiFi and Bluetooth are both handled by the same module. It is a 
 
 The CMOS battery supplies power to the system's CMOS chip. UEFI settings and the computer's hardware clock are stored on the CMOS. If your system doesn't boot, you can reset the CMOS to force a low-level hardware reset. If your clock is constantly resetting, it's likely your CMOS battery needs to be replaced.
 
+**Warning (ingestion hazard):** Keep batteries out of reach of children. Death or serious injury can occur if ingested. If a battery is suspected to be swallowed or inserted inside any part of the body, seek immediate medical attention. In the US, you can also call the National Battery Ingestion Hotline for guidance: [1 (800) 498-8666](tel:18004988666)
+
 **Tools required:** Cross-head (Phillips) screwdriver    
 **Time estimate:** 10 minutes    
 **Difficulty:** Easy <span style="color:green;">●</span>

--- a/src/models/pang11/repairs.md
+++ b/src/models/pang11/repairs.md
@@ -112,6 +112,8 @@ Your Pangolin's WiFi and Bluetooth are both handled by the same module. It is a 
 
 The CMOS battery supplies power to the system's CMOS chip. UEFI settings and the computer's hardware clock are stored on the CMOS. If your system doesn't boot, you can reset the CMOS to force a low-level hardware reset. If your clock is constantly resetting, it's likely your CMOS battery needs to be replaced.
 
+**Warning (ingestion hazard):** Keep batteries out of reach of children. Death or serious injury can occur if ingested. If a battery is suspected to be swallowed or inserted inside any part of the body, seek immediate medical attention. In the US, you can also call the National Battery Ingestion Hotline for guidance: [1 (800) 498-8666](tel:18004988666)
+
 **Tools required:** Cross-head (Phillips) screwdriver    
 **Time estimate:** 10 minutes    
 **Difficulty:** Medium <span style="color:orange;">●</span>

--- a/src/models/pang12/repairs.md
+++ b/src/models/pang12/repairs.md
@@ -100,6 +100,8 @@ Your Pangolin's WiFi and Bluetooth are both handled by the same module. It is a 
 
 The CMOS battery supplies power to the system's CMOS chip. UEFI settings and the computer's hardware clock are stored on the CMOS. If your system doesn't boot, you can reset the CMOS to force a low-level hardware reset. If your clock is constantly resetting, it's likely your CMOS battery needs to be replaced.
 
+**Warning (ingestion hazard):** Keep batteries out of reach of children. Death or serious injury can occur if ingested. If a battery is suspected to be swallowed or inserted inside any part of the body, seek immediate medical attention. In the US, you can also call the National Battery Ingestion Hotline for guidance: [1 (800) 498-8666](tel:18004988666)
+
 **Tools required:** Cross-head (Phillips) screwdriver    
 **Time estimate:** 10 minutes    
 **Difficulty:** Medium <span style="color:orange;">●</span>

--- a/src/models/pang13/repairs.md
+++ b/src/models/pang13/repairs.md
@@ -101,6 +101,8 @@ Your Pangolin's WiFi and Bluetooth are both handled by the same module. It is a 
 
 The CMOS battery supplies power to the system's CMOS chip. UEFI settings and the computer's hardware clock are stored on the CMOS. If your system doesn't boot, you can reset the CMOS to force a low-level hardware reset. If your clock is constantly resetting, it's likely your CMOS battery needs to be replaced.
 
+**Warning (ingestion hazard):** Keep batteries out of reach of children. Death or serious injury can occur if ingested. If a battery is suspected to be swallowed or inserted inside any part of the body, seek immediate medical attention. In the US, you can also call the National Battery Ingestion Hotline for guidance: [1 (800) 498-8666](tel:18004988666)
+
 **Tools required:** Cross-head (Phillips) screwdriver    
 **Time estimate:** 10 minutes    
 **Difficulty:** Medium <span style="color:orange;">●</span>

--- a/src/models/pang14/repairs.md
+++ b/src/models/pang14/repairs.md
@@ -110,6 +110,8 @@ Your Pangolin's WiFi and Bluetooth are both handled by the same module. It is a 
 
 The CMOS battery supplies power to the system's CMOS chip. UEFI settings and the computer's hardware clock are stored on the CMOS. If your system doesn't boot, you can reset the CMOS to force a low-level hardware reset. If your clock is constantly resetting, it's likely your CMOS battery needs to be replaced.
 
+**Warning (ingestion hazard):** Keep batteries out of reach of children. Death or serious injury can occur if ingested. If a battery is suspected to be swallowed or inserted inside any part of the body, seek immediate medical attention. In the US, you can also call the National Battery Ingestion Hotline for guidance: [1 (800) 498-8666](tel:18004988666)
+
 **Part numbers:**
 - The CMOS battery is a standard 3V EVE CR2032 battery.
 

--- a/src/models/pang15/repairs.md
+++ b/src/models/pang15/repairs.md
@@ -127,6 +127,8 @@ Your Pangolin's WiFi and Bluetooth are both handled by the same module, which is
 
 The CMOS battery supplies power to the system's CMOS chip. UEFI settings and the computer's hardware clock are stored on the CMOS. If your system doesn't boot, you can reset the CMOS to force a low-level hardware reset. If your clock is constantly resetting, it's likely your CMOS battery needs to be replaced.
 
+**Warning (ingestion hazard):** Keep batteries out of reach of children. Death or serious injury can occur if ingested. If a battery is suspected to be swallowed or inserted inside any part of the body, seek immediate medical attention. In the US, you can also call the National Battery Ingestion Hotline for guidance: [1 (800) 498-8666](tel:18004988666)
+
 **Part numbers:**
 - The CMOS battery is a standard 3V CR2032 battery. The stock battery is Malak brand.
 

--- a/src/models/serw12/repairs.md
+++ b/src/models/serw12/repairs.md
@@ -201,6 +201,8 @@ The Serval WS uses an AM4 socket for the CPU. If you are upgrading or replacing 
 
 The CMOS battery supplies power to the system's CMOS chip. UEFI settings and the comptuer's hardware clock are stored on the CMOS. If your system doesn't boot, you can reset the CMOS to force a low-level hardware reset. If your clock is constantly resetting, it's likely your CMOS battery needs to be replaced.
 
+**Warning (ingestion hazard):** Keep batteries out of reach of children. Death or serious injury can occur if ingested. If a battery is suspected to be swallowed or inserted inside any part of the body, seek immediate medical attention. In the US, you can also call the National Battery Ingestion Hotline for guidance: [1 (800) 498-8666](tel:18004988666)
+
 **Tools required:** Cross-head (Phillips) screwdriver    
 **Time estimate:** 10 minutes    
 **Difficulty:** Easy <span style="color:green;">●</span>

--- a/src/models/serw13/repairs.md
+++ b/src/models/serw13/repairs.md
@@ -198,6 +198,8 @@ Your Serval WS's WiFi and Bluetooth are both handled by the same module. It is a
 
 The CMOS battery supplies power to the system's CMOS chip. UEFI settings and the comptuer's hardware clock are stored on the CMOS. If your system doesn't boot, you can reset the CMOS to force a low-level hardware reset. If your clock is constantly resetting, it's likely your CMOS battery needs to be replaced.
 
+**Warning (ingestion hazard):** Keep batteries out of reach of children. Death or serious injury can occur if ingested. If a battery is suspected to be swallowed or inserted inside any part of the body, seek immediate medical attention. In the US, you can also call the National Battery Ingestion Hotline for guidance: [1 (800) 498-8666](tel:18004988666)
+
 **Tools required:** Cross-head (Phillips) screwdriver    
 **Time estimate:** 10 minutes    
 **Difficulty:** Easy <span style="color:green;">●</span>

--- a/src/models/thelio-astra-a1-n1/repairs.md
+++ b/src/models/thelio-astra-a1-n1/repairs.md
@@ -234,6 +234,8 @@ Depending on your motherboard and firmware version, the boot splash screen may n
 
 The CMOS battery supplies power to the system's CMOS chip. UEFI settings and the computer's hardware clock are stored on the CMOS. If your system doesn't boot, you can reset the CMOS to force a low-level hardware reset. If your clock is constantly resetting, it's likely your CMOS battery needs to be replaced.
 
+**Warning (ingestion hazard):** Keep batteries out of reach of children. Death or serious injury can occur if ingested. If a battery is suspected to be swallowed or inserted inside any part of the body, seek immediate medical attention. In the US, you can also call the National Battery Ingestion Hotline for guidance: [1 (800) 498-8666](tel:18004988666)
+
 **Part numbers:**
 - The CMOS battery is a standard CR2032 battery. The stock battery is Toshiba brand.
 

--- a/src/models/thelio-major-r5-n3/repairs.md
+++ b/src/models/thelio-major-r5-n3/repairs.md
@@ -238,6 +238,8 @@ Thelio Major ships with one dedicated GPU in the PCIe 5.0 x16 slot (top slot). G
 
 The CMOS battery supplies power to the system's CMOS chip. UEFI settings and the computer's hardware clock are stored on the CMOS. If your system doesn't boot, you can reset the CMOS to force a low-level hardware reset. If your clock is constantly resetting, it's likely your CMOS battery needs to be replaced.
 
+**Warning (ingestion hazard):** Keep batteries out of reach of children. Death or serious injury can occur if ingested. If a battery is suspected to be swallowed or inserted inside any part of the body, seek immediate medical attention. In the US, you can also call the National Battery Ingestion Hotline for guidance: [1 (800) 498-8666](tel:18004988666)
+
 **Part numbers:**
 - The CMOS battery is a standard KTS CR2032 battery.
 

--- a/src/models/thelio-mira-b4-n3/repairs.md
+++ b/src/models/thelio-mira-b4-n3/repairs.md
@@ -250,6 +250,8 @@ Thelio Mira ships with an optional dedicated GPU in the PCIe 5.0 x16 slot (top s
 
 The CMOS battery supplies power to the system's CMOS chip. UEFI settings and the computer's hardware clock are stored on the CMOS. If your system doesn't boot, you can reset the CMOS to force a low-level hardware reset. If your clock is constantly resetting, it's likely your CMOS battery needs to be replaced.
 
+**Warning (ingestion hazard):** Keep batteries out of reach of children. Death or serious injury can occur if ingested. If a battery is suspected to be swallowed or inserted inside any part of the body, seek immediate medical attention. In the US, you can also call the National Battery Ingestion Hotline for guidance: [1 (800) 498-8666](tel:18004988666)
+
 **Part numbers:**
 - The CMOS battery is a standard KTS CR2032 battery.
 

--- a/src/models/thelio-spark-b1-n2/repairs.md
+++ b/src/models/thelio-spark-b1-n2/repairs.md
@@ -218,6 +218,8 @@ If the wireless card is removed and the first GPU is three or fewer slots tall, 
 
 The CMOS battery supplies power to the system's CMOS chip. UEFI settings and the computer's hardware clock are stored on the CMOS. If your system doesn't boot, you can reset the CMOS to force a low-level hardware reset. If your clock is constantly resetting, it's likely your CMOS battery needs to be replaced.
 
+**Warning (ingestion hazard):** Keep batteries out of reach of children. Death or serious injury can occur if ingested. If a battery is suspected to be swallowed or inserted inside any part of the body, seek immediate medical attention. In the US, you can also call the National Battery Ingestion Hotline for guidance: [1 (800) 498-8666](tel:18004988666)
+
 **Tools required:** Cross-head (Phillips) screwdriver  
 **Time estimate:** 20 minutes  
 **Difficulty:** Medium <span style="color:orange;">●</span>


### PR DESCRIPTION
Adds ingestion hazard warning to all sections including mention of a CMOS battery in order to comply with [Reese's Law](https://www.congress.gov/bill/117th-congress/house-bill/5313). This exact verbiage is not required and can be tweaked if desired in the future, but it was drafted based on documentation from the [Federal Register](https://www.federalregister.gov/documents/2023/09/21/2023-20334/safety-standard-for-button-cell-or-coin-batteries-and-consumer-products-containing-such-batteries) and the [Consumer Product Safety Commission](https://www.cpsc.gov/Business--Manufacturing/Business-Education/Business-Guidance/Button-Cell-and-Coin-Battery).