### PR TITLE
add new CPU fan being used

### DIFF
--- a/src/models/nebula19-1/README.md
+++ b/src/models/nebula19-1/README.md
@@ -18,8 +18,11 @@ The System76 nebula19 is a desktop chassis (for DIY builds) with the following s
 - Cooling capacity
     - 2x 92mm CPU fans
         - Rear exhaust fan: Be Quiet! `PUW2-9225-MR-PWM`
-        - CPU cooler (optional add-on): Noctua `NH-U9S`
-            - Fan included with add-on: Noctua `NF-A9 PWM`
+        - CPU cooler (optional add-on): 
+            - After April 2024: Be Quiet! Pure Rock Slim 2 (`BK030`)
+                - Fan included with add-on: Be Quiet! `PUW2-9225-MR-PWM`
+            - Before April 2024: Noctua `NH-U9S`
+                - Fan included with add-on: Noctua `NF-A9 PWM`
     - 1x 140mm bottom intake fan: Be Quiet! `SIW4-14025-LF-PWM`
     - 1x 120mm side intake fan (optional add-on): Be Quiet! `SIW4-12025-MF-PWM`
 - Daughterboards

--- a/src/models/nebula19-1/assembly.md
+++ b/src/models/nebula19-1/assembly.md
@@ -52,7 +52,7 @@ The top case can be removed to access the internal components.
 
 ## Removing the CPU duct:
 
-The CPU duct supports one or more of the CPU fans and guides airflow from the side of the case through the CPU radiator to the back exhaust vent. The CPU duct is custom-designed to work with the Noctua `NH-U9S` CPU cooler that's optionally included with nebula19.
+The CPU duct supports one or more of the CPU fans and guides airflow from the side of the case through the CPU radiator to the back exhaust vent. The CPU duct is custom-designed to work with the Noctua `NH-U9S` CPU cooler (before April 2024) or the Be Quiet! Pure Rock Slim 2 `BK030` (after April 2024) that's optionally included with nebula19.
 
 ![CPU duct](./img/cpu-duct.webp)
 
@@ -97,7 +97,8 @@ In addition, nebula19 ships with the following non-installed accessories:
 - 1x Bottom case fan
     - Be Quiet! Silent Wings 4 140mm (`BQ SIW4-14025-LF-PWM`)
 - 1x CPU cooler w/ fan (optional)
-    - Noctua `NH-U9S` cooler w/ `NF-A9 PWM` fan
+    - After April 2024: Be Quiet! Pure Rock Slim 2 (`BK030`) w/ Pure Wings 2 92mm (`BQ PUW2-9225-MR-PWM`)
+    - Before April 2024: Noctua `NH-U9S` cooler w/ `NF-A9 PWM` fan
 - 1x Side bracket fan (optional)
     - Be Quiet! Silent Wings 4 120mm (`BQ SIW4-12025-MF-PWM`)
 
@@ -171,7 +172,7 @@ Four standoffs and motherboard screws are included.
 
 ## Installing the CPU duct fans:
 
-nebula19 ships with one 92mm fan (`BQ PUW2-9225-MR-PWM`) installed in the back of the CPU duct. If you install a CPU cooler with its own 92mm fan, such as the optional Noctua `NH-U9S` cooler sold with nebula19 (which includes a Noctua `NF-A9 PWM` fan), then the CPU cooler's fan can be mounted in the front of the CPU duct.
+nebula19 ships with one 92mm fan (`BQ PUW2-9225-MR-PWM`) installed in the back of the CPU duct. If you install a CPU cooler with its own 92mm fan, such as the optional Be Quiet! Pure Rock Slim 2 `BK030` or Noctua `NH-U9S` coolers sold with nebula19 (which include an additional `BQ PUW2-9225-MR-PWM` fan or a Noctua `NF-A9 PWM` fan, respectively), then the CPU cooler's fan can be mounted in the front of the CPU duct.
 
 These instructions use the Noctua `NH-U9S` as an example.
 


### PR DESCRIPTION
This adds the CPU cooler that is being used in recent nebula19 cases as the optional CPU cooler.

I have not found a part number itself for the cooler or for the fans like we have it for the Noctua that was originally used. I added similar to have the have LCD panel options or Wi-Fi options such as in the latest Lemur Pro (lemp13).

