### PR TITLE
thelio-astra-a1-n1: Update info about 1.1 revision

### DIFF
--- a/src/models/thelio-astra-a1-n1/README.md
+++ b/src/models/thelio-astra-a1-n1/README.md
@@ -18,11 +18,9 @@ The System76 Thelio Astra is a desktop with the following specifications:
         - [Ampere Altra Q80-30](https://amperecomputing.com/briefs/ampere-altra-family-product-brief)
         - [Ampere Altra Q64-22](https://amperecomputing.com/briefs/ampere-altra-family-product-brief)
         - [Ampere Altra Q32-17](https://amperecomputing.com/briefs/ampere-altra-family-product-brief)
-- Motherboard options (depending on order date and/or stock availability)
-    - [ASRock ALTRAD8UD-1L2T](https://www.asrockrack.com/general/productdetail.asp?Model=ALTRAD8UD-1L2T#Specifications) running System76 Firmware (non-open)
-        - Used for orders before November 2024.
-    - [ASRock ALTRAD8UD2-1L2Q](https://www.asrockrack.com/general/productdetail.asp?Model=ALTRAD8UD2-1L2Q#Specifications) running System76 Firmware (non-open)
-        - Used for orders after November 2024.
+- Motherboard options
+    - Revision 1.1: [ASRock ALTRAD8UD-1L2T](https://www.asrockrack.com/general/productdetail.asp?Model=ALTRAD8UD-1L2T#Specifications) running System76 Firmware (non-open)
+    - Revision 1: [ASRock ALTRAD8UD2-1L2Q](https://www.asrockrack.com/general/productdetail.asp?Model=ALTRAD8UD2-1L2Q#Specifications) running System76 Firmware (non-open)
 - Daughterboard
     - [Thelio Io](https://github.com/system76/thelio-io) board running [open-source firmware](https://github.com/system76/thelio-io-firmware)
         - Version 2.3

--- a/src/models/thelio-astra-a1-n1/external-overview.md
+++ b/src/models/thelio-astra-a1-n1/external-overview.md
@@ -6,8 +6,9 @@
 
 ### SFP Port Information:
 
-- When ordering Thelio Astra, options for one or two 10GbE RJ-45 transceivers preinstalled into the 25GbE SFP port(s) are offered.
+- When ordering Thelio Astra revision A1 (with the `ALTRAD8UD2-1L2Q` motherboard), options for one or two 10GbE RJ-45 transceivers preinstalled into the 25GbE SFP port(s) are offered.
     - No transceivers are installed in the photo above.
+- Thelio Astra revision A1.1 (with the `ALTRAD8UD-1L2T` motherboard) includes two built-in 10GbE RJ-45 ports instead of SFP ports.
 
 ### Unit Identification (UID) Button Guide:
 

--- a/src/models/thelio-astra-a1-n1/repairs.md
+++ b/src/models/thelio-astra-a1-n1/repairs.md
@@ -2,7 +2,8 @@
 
 Many components in your Thelio Astra can be upgraded or replaced as necessary. This page uses photos of the the A1-N1 revision, which indicates:
 
-- **A1:** The first Ampere-compatible motherboard used in Thelio Astra.
+- **A1:** The first Ampere-compatible motherboard used in Thelio Astra (`ALTRAD8UD2-1L2Q`).
+    - Units marked **A1.1** include the `ALTRAD8UD-1L2T` motherboard instead.
 - **N1:** The first chassis revision of the Thelio Astra.
     - The Thelio Astra chassis is based on the nebula40 chassis (revision 3), but lacks top I/O and 2.5" drive mounts.
 


### PR DESCRIPTION
This was a fairly simple change to make since we already referred to the variants by motherboard model instead of by date in most locations.

Closes #292.