### PR TITLE
nebula19, 40, 49: Add CPU cooler max dimensions

### DIFF
--- a/src/models/nebula19-1/README.md
+++ b/src/models/nebula19-1/README.md
@@ -18,11 +18,16 @@ The System76 nebula19 is a desktop chassis (for DIY builds) with the following s
 - Cooling capacity
     - 2x 92mm CPU fans
         - Rear exhaust fan: Be Quiet! `PUW2-9225-MR-PWM`
-        - CPU cooler (optional add-on): 
-            - After April 2024: Be Quiet! Pure Rock Slim 2 (`BK030`)
-                - Fan included with add-on: Be Quiet! `PUW2-9225-MR-PWM`
-            - Before April 2024: Noctua `NH-U9S`
-                - Fan included with add-on: Noctua `NF-A9 PWM`
+        - CPU cooler:              
+            - Optional included cooler:
+                - After April 2024: Be Quiet! Pure Rock Slim 2 (`BK030`)
+                    - Included cooler fan: Be Quiet! `PUW2-9225-MR-PWM`
+                - Before April 2024: Noctua `NH-U9S`
+                    - Included cooler fan: Noctua `NF-A9 PWM`
+            - Max dimensions:
+                - Height (top to bottom of duct): 106mm
+                - Width (motherboard to side of duct): 133mm
+                - Length (front to back within duct): 125mm (104mm with fans)  
     - 1x 140mm bottom intake fan: Be Quiet! `SIW4-14025-LF-PWM`
     - 1x 120mm side intake fan (optional add-on): Be Quiet! `SIW4-12025-MF-PWM`
 - Daughterboards

--- a/src/models/nebula40-3/README.md
+++ b/src/models/nebula40-3/README.md
@@ -22,9 +22,13 @@ The System76 nebula40 is a desktop chassis (for DIY builds) with the following s
 - Cooling capacity
     - 1x 140mm bottom intake fan
         - Be Quiet! `SIW4-14025-LF-PWM`
-    - CPU cooler (optional add-on)
-        - Thermalright Phantom Spirit 120SE
-        - Includes 2x Thermalright `TL-C12B V2 PWM` 120mm fans
+    - CPU cooler
+        - Optional included cooler: Thermalright Phantom Spirit 120SE
+            - Includes 2x Thermalright `TL-C12B V2 PWM` 120mm fans
+        - Max dimensions:
+            - Height (top to bottom of duct): 143mm
+            - Width (motherboard to side of duct): 170mm
+            - Length (front to back within duct): 176.3mm (126mm with fans)
     - 1x 120mm side intake fan (optional add-on)
         - Be Quiet! `SIW4-12025-MF-PWM`
 - Daughterboards

--- a/src/models/nebula49-1/README.md
+++ b/src/models/nebula49-1/README.md
@@ -22,8 +22,13 @@ The System76 nebula49 is a desktop chassis (for DIY builds) with the following s
 - Cooling capacity
     - 2x 120mm CPU fans
         - Rear exhaust fan: Be Quiet! `SIW4-12025-MF-PWM`
-        - CPU cooler (optional add-on): Noctua `NH-U12S`
-            - Fan included with add-on: Noctua `NF-F12 PWM`
+        - CPU cooler:
+            - Optional included cooler: Noctua `NH-U12S`
+                - Includes 1x Noctua `NF-F12 PWM` fan
+            - Max dimensions:
+                - Height (top to bottom of duct): 142mm
+                - Width (motherboard to side of duct): 163mm
+                - Length (front to back within duct): 258mm (215mm with fans)
     - 1x 140mm bottom intake fan: Be Quiet! `SIW4-14025-HF-PWM`
     - 2x 120mm side intake fans
         - Optional add-on: Be Quiet! `SIW4-12025-MF-PWM`


### PR DESCRIPTION
Mechanical engineering provided this information. I tried to explain what each dimension means without needing a separate diagram like our internal document uses.