### PR TITLE
bonw16: Overview & repairs

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -4,6 +4,8 @@
     - [Adder WS (addw5)](models/addw5/README.md)
         - [Parts & Repairs](models/addw5/repairs.md)
     - [Bonobo WS (bonw16)](models/bonw16/README.md)
+        - [External Overview](models/bonw16/external-overview.md)
+        - [Internal Overview](models/bonw16/internal-overview.md)
         - [Parts & Repairs](models/bonw16/repairs.md)
     - [Darter Pro (darp11)](models/darp11/README.md)
         - [External Overview](models/darp11/external-overview.md)

--- a/src/models/addw3/repairs.md
+++ b/src/models/addw3/repairs.md
@@ -137,9 +137,11 @@ The CMOS battery supplies power to the system's CMOS chip. UEFI settings and the
 
 The Adder WS 3 has a single heatsink assembly with two fans. This assembly cools the CPU and GPU.
 
-If the fans become noisy and cleaning them out doesn't fix the issue, you may need a new fan. [Contact support](https://support.system76.com) to start a warranty claim or parts purchase.
+If the fans become noisy and cleaning them out doesn't fix the issue, you may need a new fan. [Contact support](https://support.system76.com) to start a warranty claim or parts purchase. These instructions can also be used if physical damage to the heatsink necessitates its replacement.
 
-Depending on your climate and the age of the machine, it may be necessary to apply new thermal paste between the CPU/GPU and the heatsink. Thermal paste helps facilitate effective heat transfer between the CPU/GPU and the cooling equipment. These instructions can also be used in the unlikely event your heatsink needs to be replaced.
+Thermal paste helps facilitate effective heat transfer between the CPU/GPU and the cooling equipment; depending on your climate and the age of the machine, replacing the thermal paste may improve cooling performance. The thermal paste should generally be replaced whenever the heatsink is removed.
+
+Thermal putty (thicker than thermal paste) is used to bridge the gap between the VRAM chips and the heatsink. Replacing the thermal putty is optional when removing the heatsink. System76 suggests [Thermal Grizzly Putty Basic](https://www.thermal-grizzly.com/en/tg-putty/s-tg-p-b-030) (available at various retailers) or a similar alternative.
 
 **Tools required:** Cross-head (Phillips) screwdriver  
 **Time estimate:** 25 minutes  
@@ -158,11 +160,14 @@ Depending on your climate and the age of the machine, it may be necessary to app
 
 4. Unplug the two white fan connectors from the motherboard (highlighted yellow above).
 5. Remove the heatsink/fans from the case, being careful not to bend the heatsink pipes. It may take some pressure to break the seal of the thermal paste.
-6. Using a paper towel, remove the existing thermal paste from the CPU, GPU, VRAM chips, and heatsink. You may also use a small amount of rubbing alcohol if the old paste is dried or difficult to remove.
+6. Using a paper towel, remove the existing thermal paste from the CPU, GPU, and heatsink. You may also use a small amount of rubbing alcohol if the old paste is dried or difficult to remove.
+    - You can optionally remove the thermal putty from the four VRAM chips surrounding the GPU chip if you have replacement thermal putty to install.
 
 ![Thermal paste removal](./img/thermal-paste-removal.webp)
 
-7. Apply a small line of thermal paste directly onto the CPU chip, GPU chip, and VRAM chips.
+7. Apply a small line of thermal paste directly onto the CPU chip and the GPU chip.
+    - If you're also replacing the thermal putty, apply the new putty to the four VRAM chips.
+    - If you aren't replacing the thermal putty, scoop the existing putty (from the VRAM chip and the corresponding location on the heatsink) into the center of each VRAM chip using a flat plastic tool.
 
 ![Thermal paste application](./img/thermal-paste-application.webp)
 

--- a/src/models/addw4/repairs.md
+++ b/src/models/addw4/repairs.md
@@ -149,17 +149,18 @@ Your Adder WS's WiFi and Bluetooth are both handled by the same module. It is a 
 
 The Adder WS 4 has a single heatsink assembly with two fans. This assembly cools the CPU and GPU.
 
-If the fans become noisy and cleaning them out doesn't fix the issue, you may need a new fan. [Contact support](https://support.system76.com) to start a warranty claim or parts purchase.
+If the fans become noisy and cleaning them out doesn't fix the issue, you may need a new fan. [Contact support](https://support.system76.com) to start a warranty claim or parts purchase. These instructions can also be used if physical damage to the heatsink necessitates its replacement.
 
-Depending on your climate and the age of the machine, it may be necessary to apply new thermal paste between the CPU/GPU and the heatsink. Thermal paste helps facilitate effective heat transfer between the CPU/GPU and the cooling equipment. These instructions can also be used in the unlikely event your heatsink needs to be replaced.
+Thermal paste helps facilitate effective heat transfer between the CPU/GPU and the cooling equipment; depending on your climate and the age of the machine, replacing the thermal paste may improve cooling performance. The thermal paste should generally be replaced whenever the heatsink is removed.
+
+Thermal putty (thicker than thermal paste) is used to bridge the gap between the VRAM chips and the heatsink. Replacing the thermal putty is optional when removing the heatsink. System76 suggests [Thermal Grizzly Putty Basic](https://www.thermal-grizzly.com/en/tg-putty/s-tg-p-b-030) (available at various retailers) or a similar alternative.
 
 **Part numbers:**
 - The fan/heatsink assembly's manufacturer and part number is Yingfan `6-31-V350N-201`.
 - The left fan (with stamped numbers 1/2/3) is a WINMA `EGC-85071S1-0AH`.
 - The right fan (with stamped numbers 4/5/6) is a WINMA `ECG-79731S1-0AH`.
 
-
-**Tools required:** Cross-head (Phillips) screwdriver  
+**Tools required:** Cross-head (Phillips) screwdriver, thermal putty spreader (flat plastic tool)  
 **Time estimate:** 25 minutes  
 **Difficulty:** High <span style="color:red;">●</span>  
 
@@ -175,11 +176,14 @@ Depending on your climate and the age of the machine, it may be necessary to app
 
 4. Unplug the two black fan connectors from the motherboard (highlighted green above).
 5. Remove the heatsink/fans from the case, being careful not to bend the heatsink pipes. It may take some pressure to break the seal of the thermal paste.
-6. Using a paper towel, remove the existing thermal paste from the CPU, GPU, VRAM chips, and heatsink. You may also use a small amount of rubbing alcohol if the old paste is dried or difficult to remove.
+6. Using a paper towel, remove the existing thermal paste from the CPU, GPU, and heatsink. You may also use a small amount of rubbing alcohol if the old paste is dried or difficult to remove.
+    - You can optionally remove the thermal putty from the four VRAM chips surrounding the GPU chip if you have replacement thermal putty to install.
 
 ![Thermal paste removal](./img/thermal-paste-removal.webp)
 
-7. Apply a small line of thermal paste directly onto the CPU chip, GPU chip, and VRAM chips.
+7. Apply a small line of thermal paste directly onto the CPU chip and the GPU chip.
+    - If you're also replacing the thermal putty, apply the new putty to the four VRAM chips.
+    - If you aren't replacing the thermal putty, scoop the existing putty (from the VRAM chip and the corresponding location on the heatsink) into the center of each VRAM chip using a flat plastic tool.
 
 ![Thermal paste application](./img/thermal-paste-application.webp)
 

--- a/src/models/bonw15/repairs.md
+++ b/src/models/bonw15/repairs.md
@@ -244,7 +244,7 @@ The keyboard includes per-key RGB LED backlighting, and can be replaced using th
 6. Flip the black latches upwards to free the ribbon cables.
 7. Pull the ribbon cables out of the connectors.
 8. Remove the keyboard and replace it with the new one.
-9. Carefully slide both ribbon cables into their connectors.
+9. Carefully slide all three ribbon cables into their connectors.
 10. Flip the black latches back into place to secure the ribbon cables.
 11. (Optional) Replace the keyboard adhesive strip on the chassis.
 12. Place the keyboard back into position, starting with the tabs on the bottom edge.

--- a/src/models/bonw15/repairs.md
+++ b/src/models/bonw15/repairs.md
@@ -142,11 +142,13 @@ The CMOS battery supplies power to the system's CMOS chip. UEFI settings and the
 
 The Bonobo WS 15 has a single heatsink assembly with two fans. This assembly cools the CPU and GPU.
 
-If the fans become noisy and cleaning them out doesn't fix the issue, you may need a new fan. [Contact support](https://support.system76.com) to start a warranty claim or parts purchase.
+If the fans become noisy and cleaning them out doesn't fix the issue, you may need a new fan. [Contact support](https://support.system76.com) to start a warranty claim or parts purchase. These instructions can also be used if physical damage to the heatsink necessitates its replacement.
 
-Depending on your climate and the age of the machine, it may be necessary to apply new thermal paste between the CPU/GPU and the heatsink. Thermal paste helps facilitate effective heat transfer between the CPU/GPU and the cooling equipment. These instructions can also be used in the unlikely event your heatsink needs to be replaced.
+Thermal paste helps facilitate effective heat transfer between the CPU/GPU and the cooling equipment; depending on your climate and the age of the machine, replacing the thermal paste may improve cooling performance. The thermal paste should generally be replaced whenever the heatsink is removed.
 
-**Tools required:** Cross-head (Phillips) screwdriver  
+Thermal putty (thicker than thermal paste) is used to bridge the gap between the VRAM chips and the heatsink. Replacing the thermal putty is optional when removing the heatsink. System76 suggests [Thermal Grizzly Putty Basic](https://www.thermal-grizzly.com/en/tg-putty/s-tg-p-b-030) (available at various retailers) or a similar alternative.
+
+**Tools required:** Cross-head (Phillips) screwdriverthermal putty spreader (flat plastic tool)  
 **Time estimate:** 15 minutes  
 **Difficulty:** High <span style="color:red;">●</span>  
 
@@ -163,11 +165,14 @@ Depending on your climate and the age of the machine, it may be necessary to app
     - The tape covering the [wireless card antennas](#replacing-the-wireless-card) may also need to be removed.
 4. Unplug the black fan connectors from the motherboard.
 5. Remove the heatsink/fans from the case, being careful not to bend the heatsink pipes. It may take some pressure to break the seal of the thermal paste.
-6. Using a paper towel, remove the existing thermal paste from the CPU, GPU, VRAM chips, and heatsink. You may also use a small amount of rubbing alcohol if the old paste is dried or difficult to remove.
+6. Using a paper towel, remove the existing thermal paste from the CPU, GPU, and heatsink. You may also use a small amount of rubbing alcohol if the old paste is dried or difficult to remove.
+    - You can optionally remove the thermal putty from the eight VRAM chips surrounding the GPU chip if you have replacement thermal putty to install.
 
 ![Thermal paste removal](./img/thermal-paste-removal.webp)
 
-7. Apply a small line of thermal paste directly onto the CPU chip, GPU chip, and VRAM chips.
+7. Apply a small line of thermal paste directly onto the CPU chip and the GPU chip.
+    - If you're also replacing the thermal putty, apply the new putty to the eight VRAM chips.
+    - If you aren't replacing the thermal putty, scoop the existing putty (from the VRAM chip and the corresponding location on the heatsink) into the center of each VRAM chip using a flat plastic tool.
 
 ![Thermal paste application](./img/thermal-paste-application.webp)
 

--- a/src/models/bonw16/README.md
+++ b/src/models/bonw16/README.md
@@ -37,7 +37,9 @@ The System76 Bonobo WS is a laptop with the following specifications:
         - 1x HDMI 2.1
         - 2x DisplayPort 2.1 over USB-C
 - Memory
-    - Up to 192GB (4x48GB) dual-channel DDR5 SO-DIMMs @ 5600 MHz
+    - Up to 192GB (4x48GB) dual-channel DDR5 SO-DIMMs
+        - Single-rank RAM and 1x dual-rank RAM speed: 4400MHz
+        - 2x/3x/4x dual-rank RAM speed: 4000MHz
 - Networking
     - 2.5-Gigabit Ethernet
     - M.2 PCIe/CNVi WiFi/Bluetooth:

--- a/src/models/bonw16/README.md
+++ b/src/models/bonw16/README.md
@@ -1,5 +1,9 @@
 # Bonobo WS (bonw16)
 
+- [External Overview](./external-overview.md)
+- [Internal Overview](./internal-overview.md)
+- [Parts & Repairs](./repairs.md)
+
 ![Bonobo WS](./img/bonw16.png)
 
 The System76 Bonobo WS is a laptop with the following specifications:
@@ -42,6 +46,7 @@ The System76 Bonobo WS is a laptop with the following specifications:
 - Power
     - 330W (20V, 16.5A) DC-in port
         - Barrel size: 5.5mm (outer), 2.5mm (inner)
+    - Included AC adapter: FSP FSP330-ACAU3
     - 98Wh 8-cell Lithium-Ion battery
         - Model number: X580BAT-8-98
 - Sound

--- a/src/models/bonw16/external-overview.md
+++ b/src/models/bonw16/external-overview.md
@@ -1,0 +1,72 @@
+# Bonobo WS (External Overview)
+
+## Left side:
+
+![Left Ports](./img/ports-left.png)
+
+## Right side:
+
+![Right Ports](./img/ports-right.png)
+
+## Front side:
+
+![Front Ports](./img/ports-front.webp)
+
+## Back side:
+
+![Back Ports](./img/ports-back.png)
+
+## Keyboard & touchpad:
+
+![Keyboard & Touchpad](./img/keyboard-touchpad.png)
+
+## Lid:
+
+![Lid](./img/lid.png)
+
+## Materials:
+
+|Part                              |Material |Part Number        |
+|----------------------------------|---------|-------------------|
+|LCD back cover (lid)              |Aluminum |6-39-X5801-023     |
+|LCD front cover (bezel)           |Plastic  |6-39-X5801-013     |
+|Top case (palm rests/port covers) |Aluminum |6-39-X5802-013 <br/>or 6-39-X5802-011-L |
+|Bottom panel                      |Aluminum |6-39-X5803-013     |
+
+## LED indicators
+
+The Bonobo WS has the following LED indicators:
+
+|Icon                                    |Color          |Description                      |
+|----------------------------------------|---------------|---------------------------------|
+|![Power LED](./img/led-power.png)       |Orange         |Powered off, DC power plugged in |
+|                                        |Green          |Powered on                       |
+|                                        |Blinking green |Sleeping (suspended)             |
+|![Battery LED](./img/led-battery.png)   |Orange         |Battery charging                 |
+|                                        |Green          |Battery fully charged            |
+|                                        |Blinking orange|Battery critically low           |
+|![Storage LED](./img/led-storage.png)   |Green          |Storage drive activity           |
+
+### Keyboard Shortcuts
+
+The Bonobo WS has the following actions available using the Fn and Function keys:
+
+|Key                        |Shortcut|Action                             |
+|---------------------------|--------|-----------------------------------|
+|![Fn-F1](./img/fn-f1.png)  |Fn+F1   |Toggle trackpad                    |
+|![Fn-F2](./img/fn-f2.png)  |Fn+F2   |Toggle microphone mute             |
+|![Fn-F3](./img/fn-f3.png)  |Fn+F3   |Mute                               |
+|![Fn-F5](./img/fn-f5.png)  |Fn+F5   |Volume down                        |
+|![Fn-F6](./img/fn-f6.png)  |Fn+F6   |Volume up                          |
+|![Fn-F7](./img/fn-f7.png)  |Fn+F7   |Toggle displays                    |
+|![Fn-F8](./img/fn-f8.png)  |Fn+F8   |Screen brightness down             |
+|![Fn-F9](./img/fn-f9.png)  |Fn+F9   |Screen brightness up               |
+|![Fn-F10](./img/fn-f10.png)|Fn+F10  |Toggle webcam                      |
+|![Fn-F11](./img/fn-f11.png)|Fn+F11  |Toggle airplane mode               |
+|![Fn-F12](./img/fn-f12.png)|Fn+F12  |Suspend                            |
+|![Fn-F12](./img/fn-dia.jpg)|Fn+`    |Play/Pause                         |
+|![Fn-*](./img/fn-star.png) |Fn+*    |Toggle keyboard backlight          |
+|![Fn-/](./img/fn-slash.png)|Fn+/    |Cycle keyboard color               |
+|![Fn--](./img/fn-minus.png)|Fn+-    |Decrease keyboard brightness       |
+|![Fn-+](./img/fn-plus.png) |Fn++    |Increase keyboard brightness       |
+|1                          |Fn+1    |Toggle fan between max/automatic   |

--- a/src/models/bonw16/img/battery.webp
+++ b/src/models/bonw16/img/battery.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ed17ae0e6948324bf90518d039b92aed0682184a87c7db1772e86e73eed734a7
+size 741680

--- a/src/models/bonw16/img/bottom-panel-screws.webp
+++ b/src/models/bonw16/img/bottom-panel-screws.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e1212ee764b8b6c80f17009ac95eb0d6e8a53a30e48db5400ce12ca32a59f9bb
+size 786508

--- a/src/models/bonw16/img/cmos-battery.webp
+++ b/src/models/bonw16/img/cmos-battery.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e26257a7301cdf8b1b2cb280437001310c32b37faa680868b5f46486402bd141
+size 468868

--- a/src/models/bonw16/img/components-highlighted.webp
+++ b/src/models/bonw16/img/components-highlighted.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9ccfe982372f55b9963d257cdc32d8359002be7fe1bed01ed64e016ed6696f41
+size 983900

--- a/src/models/bonw16/img/fn-dia.jpg
+++ b/src/models/bonw16/img/fn-dia.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1d82925430d49e2479de83103490b61a43e08e2e455142d52e184dbde2935a3b
+size 820

--- a/src/models/bonw16/img/fn-f1.png
+++ b/src/models/bonw16/img/fn-f1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d17a59a7a9ef0b23e92c9317ab414e3f90e9ba8239e18c6ded06364778d9d36f
+size 998

--- a/src/models/bonw16/img/fn-f10.png
+++ b/src/models/bonw16/img/fn-f10.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8a8b6b140613288b84a5d687a484edc1c31a962f14f69a89528d7819e42d11cc
+size 650

--- a/src/models/bonw16/img/fn-f11.png
+++ b/src/models/bonw16/img/fn-f11.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:37c1ad28024da356a5423da99d92439101635f040895970fc70f9004795c7386
+size 783

--- a/src/models/bonw16/img/fn-f12.png
+++ b/src/models/bonw16/img/fn-f12.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8fe27e06755900e966eb44ecc5ed173cd5a9bc1b3be233138baecde53f6ff129
+size 1141

--- a/src/models/bonw16/img/fn-f2.png
+++ b/src/models/bonw16/img/fn-f2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b6e4ea5ef18c301f4cae75178556f26f0c95492d0dbef48a0aed529d4d587b51
+size 1653

--- a/src/models/bonw16/img/fn-f3.png
+++ b/src/models/bonw16/img/fn-f3.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dc180e350ec699931772797a9e2bc9d6a847a6892257690fd79ecbe90802fb3a
+size 1187

--- a/src/models/bonw16/img/fn-f5.png
+++ b/src/models/bonw16/img/fn-f5.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:456571f7615d84254f76c663f1c1b507c9cf8517ece8833e167d52f7d334a9f9
+size 1044

--- a/src/models/bonw16/img/fn-f6.png
+++ b/src/models/bonw16/img/fn-f6.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3554a1560a73fd843265459c5ab6d12c77628ec23bb1c9f94c9947d7a514e559
+size 1156

--- a/src/models/bonw16/img/fn-f7.png
+++ b/src/models/bonw16/img/fn-f7.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2feb5bab13d71c66c70471ef4cdcc2b9485f575aca82c2b62bfc0a2093c19ab0
+size 354

--- a/src/models/bonw16/img/fn-f8.png
+++ b/src/models/bonw16/img/fn-f8.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:221af309ec9caaffd6e415121ba6c4816178972b2bc8d52faaed447192a17ed3
+size 843

--- a/src/models/bonw16/img/fn-f9.png
+++ b/src/models/bonw16/img/fn-f9.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:866fd726774649349fabe4d88965c93ae6fafaa228afcb6ac0aaecba6f114e33
+size 870

--- a/src/models/bonw16/img/fn-minus.png
+++ b/src/models/bonw16/img/fn-minus.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fba5ac94f396df821227c2661fbfed2fd5a6459e9e888c053d7b7d6eb314312f
+size 996

--- a/src/models/bonw16/img/fn-plus.png
+++ b/src/models/bonw16/img/fn-plus.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6d1d4cad6dae0e59496455dcd4db34223a305c8b82a14c0657cb39847725c1c7
+size 1026

--- a/src/models/bonw16/img/fn-slash.png
+++ b/src/models/bonw16/img/fn-slash.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:21b29c62d33a70adb4c2297ee8e02cd449e8d3f62729b230cb605f96518f5488
+size 1304

--- a/src/models/bonw16/img/fn-star.png
+++ b/src/models/bonw16/img/fn-star.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:74c92304ad9330ac5a7338efd17f70571211a0fbd490c204b7bfd8ccea88010a
+size 1035

--- a/src/models/bonw16/img/keyboard-adhesive.webp
+++ b/src/models/bonw16/img/keyboard-adhesive.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7fcf0b32ab80cd1671b3e3195309497cc61ed5b6474f27e4859b59983841cd97
+size 841230

--- a/src/models/bonw16/img/keyboard-push-point.webp
+++ b/src/models/bonw16/img/keyboard-push-point.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ed27ace898f0436629d3c69554608f0043d65abc6027cd163441970a1df8d7cf
+size 820972

--- a/src/models/bonw16/img/keyboard-ribbons.webp
+++ b/src/models/bonw16/img/keyboard-ribbons.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:244a6eb8156e5d74c892c9d079fb25dc08ef4a78a6cefbc9378734b0360aa64a
+size 686162

--- a/src/models/bonw16/img/keyboard-touchpad.png
+++ b/src/models/bonw16/img/keyboard-touchpad.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b7c9978968d2dbc2a17826d501a12bfd00b076e23ed10f60b9d2cfefb0c9009f
+size 323771

--- a/src/models/bonw16/img/led-airplane.png
+++ b/src/models/bonw16/img/led-airplane.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:08ea82e946926fd51a286a98120792be58bbb0c166b5209d285a56e6931a11e2
+size 2780

--- a/src/models/bonw16/img/led-battery.png
+++ b/src/models/bonw16/img/led-battery.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ebfb5b1c67136df3bbf4a00d5b47f7c7d84d0e0f8f049ce685dd656099f65e11
+size 2633

--- a/src/models/bonw16/img/led-power.png
+++ b/src/models/bonw16/img/led-power.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f7877ef81cc1039d68fc71d4c185c72b51b58e15f0329e5e4ca920da955935b4
+size 3498

--- a/src/models/bonw16/img/led-storage.png
+++ b/src/models/bonw16/img/led-storage.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:31df2f761d7c0ff6621414586d0313b24ffc556a73d1b4c8ba2b6a895d5b250d
+size 3045

--- a/src/models/bonw16/img/lid.png
+++ b/src/models/bonw16/img/lid.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dca88a7289b0ccde758007c1f968f1a97bd4e3d9145532fe10e57d5a426f601d
+size 295324

--- a/src/models/bonw16/img/m2-slots.webp
+++ b/src/models/bonw16/img/m2-slots.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9564fb03f83035e58ab659eb8da34df918dc0e26bfc45fde8f034c9b41fb043c
+size 858550

--- a/src/models/bonw16/img/ports-back.png
+++ b/src/models/bonw16/img/ports-back.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a096dabcdc35f30dbc6eddc9c714356d7a7fef71caaead48ec0fe23d5e8ff7b8
+size 177353

--- a/src/models/bonw16/img/ports-front.webp
+++ b/src/models/bonw16/img/ports-front.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:00cca7f0ed82d3ca026f51f05c6880775e353511a7baf8b59e28f76af5bb3468
+size 104932

--- a/src/models/bonw16/img/ports-left.png
+++ b/src/models/bonw16/img/ports-left.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:137299350dc8c44e34451c87200751eb3505e0038f9854779d4b6ba6a3835adc
+size 190118

--- a/src/models/bonw16/img/ports-right.png
+++ b/src/models/bonw16/img/ports-right.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ffd8f3b6bf9e79322429c0b22812943a4ff9cf04ba5572c20dd4989af5ae5b0b
+size 192490

--- a/src/models/bonw16/img/ram-slots.webp
+++ b/src/models/bonw16/img/ram-slots.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8b0163da0bdb2d1a2470ae54c0a8c05c14691b865eb7002188639ae6c3d03e6e
+size 952580

--- a/src/models/bonw16/img/speaker-subwoofer.webp
+++ b/src/models/bonw16/img/speaker-subwoofer.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5593336345b4a645adeb081b57f1fae16f11c114bca8385818c8378553a9f42e
+size 1255718

--- a/src/models/bonw16/img/speakers-left-right.webp
+++ b/src/models/bonw16/img/speakers-left-right.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4e7b512fcb21211099cc0d4cec733484599732efcbbd4c3aa423324f5a7b06ee
+size 904152

--- a/src/models/bonw16/img/thermal-paste-application.webp
+++ b/src/models/bonw16/img/thermal-paste-application.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9967032d9b4fe7a9be59d0cb8624fd8443362dee3f6d0acf068432f6a16113a2
+size 952070

--- a/src/models/bonw16/img/thermal-paste-application.webp
+++ b/src/models/bonw16/img/thermal-paste-application.webp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9967032d9b4fe7a9be59d0cb8624fd8443362dee3f6d0acf068432f6a16113a2
-size 952070
+oid sha256:958a87182402add77a9a7fe022d12b7b21a973068f3af7fed7b97cddc57cf335
+size 852586

--- a/src/models/bonw16/img/thermal-paste-removal.webp
+++ b/src/models/bonw16/img/thermal-paste-removal.webp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:46fe18abb52b1077d7d340c3bda7214c55dfdb3c6f64b5aab3fe3b677d95027a
-size 957872
+oid sha256:f67f8e7ae7e1faa0ba77d706ce60b0f0535682c32737e11490661252049d1f48
+size 955246

--- a/src/models/bonw16/img/thermal-paste-removal.webp
+++ b/src/models/bonw16/img/thermal-paste-removal.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:46fe18abb52b1077d7d340c3bda7214c55dfdb3c6f64b5aab3fe3b677d95027a
+size 957872

--- a/src/models/bonw16/img/thermal-system.webp
+++ b/src/models/bonw16/img/thermal-system.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e08f43b4dde9385a8d0e3dfd4082ae71ae482ff9e9dce65e4a4013ad8c48bdb3
+size 1361310

--- a/src/models/bonw16/img/under-keyboard.webp
+++ b/src/models/bonw16/img/under-keyboard.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8ff2c2b7c39caed8ea0f20f5203cba353371363cab98620ad9e5753e67a88f0d
+size 824196

--- a/src/models/bonw16/img/wireless-card-antennas.webp
+++ b/src/models/bonw16/img/wireless-card-antennas.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e4712b438349c85db1e5e6d6bf40dbb036e7e07d2b1d91e036e16cb4dcc92ccd
+size 333766

--- a/src/models/bonw16/img/wireless-card-screw.webp
+++ b/src/models/bonw16/img/wireless-card-screw.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:476ac47a7e2485dedc654872118930496de68331793a2bfcd1d9ac844eb484b4
+size 508510

--- a/src/models/bonw16/internal-overview.md
+++ b/src/models/bonw16/internal-overview.md
@@ -1,0 +1,30 @@
+# Bonobo WS (Internal Overview)
+
+## Bottom components and connectors:
+
+![Internal Components](./img/components-highlighted.webp)
+
+- LCD panel connector is highlighted in light green
+- Webcam/microphone connector (under the heatsink) is highlighted in brown
+- Keyboard adhesive access point is highlighted in pink
+- M.2 SSDs are highlighted in dark green
+    - All slots support PCIe NVMe Gen 4
+- Wireless card (under SSD slot 4) is highlighted in cyan
+- Fan connectors are highlighted in orange
+    - CPU fan connector is located under SSD slot 1
+- CMOS battery connector is highlighted in purple
+- Speaker connectors are highlighted in yellow
+    - Right speaker connector (on the left) is partially under SSD slot 4
+- BIOS flash chip (U98) is highlighted in black
+- Main battery connector is highlighted in red
+- Touchpad connector is highlighted in white
+- RAM is highlighted in maroon
+
+## Under-keyboard components and connectors:
+
+![Under-Keyboard Connectors](./img/under-keyboard.webp)
+
+- Keyboard connector is highlighted in yellow
+- Keyboard backlight connectors are highlighted in green
+- Back light bar connector is highlighted in cyan
+- Power button/LED connector is highlighted in red

--- a/src/models/bonw16/repairs.md
+++ b/src/models/bonw16/repairs.md
@@ -1,3 +1,283 @@
 # Bonobo WS (Parts & Repairs)
 
-A service manual for the Bonobo WS 16 (bonw16) is not yet available. Please reference the service manual for the previous version, the [Bonobo WS 15 (bonw15)](/models/bonw15/repairs.md).
+Many components in your Bonobo WS can be upgraded or replaced as necessary. Follow these step-by-step guides for instructions:
+
+- [Removing the bottom cover](#removing-the-bottom-cover)
+- [Replacing the battery](#replacing-the-battery)
+- [Replacing the RAM](#replacing-the-ram)
+- [Replacing an M.2/NVMe SSD](#replacing-an-m2nvme-ssd)
+- [Replacing the WiFi/Bluetooth module](#replacing-the-wireless-card)
+- [Replacing the CMOS battery](#replacing-the-cmos-battery)
+- [Replacing the speakers](#replacing-the-speakers)
+- [Replacing the fans/heatsink/thermal paste](#replacing-the-cooling-system)
+- [Replacing the keyboard](#replacing-the-keyboard)
+
+## Removing the bottom cover:
+
+Removing the cover is required to access the internal components. Prior to removing the cover, ensure the AC power is unplugged and all peripherals (such as USB drives or Kensington locks) are unplugged or removed from the system.
+
+**Part numbers:**
+- Bottom panel: `6-39-X5803-013`
+
+**Tools required:** Cross-head (Phillips) screwdriver  
+**Time estimate:** 5 minutes  
+**Difficulty:** Easy <span style="color:green;">●</span>
+
+### Steps to remove the bottom cover:
+
+1. Place the machine lid-side down.
+    - Use a soft surface (such as a towel) to avoid scratches.
+2. Remove the 14 bottom panel screws.
+
+![Bottom panel screws](./img/bottom-panel-screws.webp)
+
+3. Pull the bottom panel off, starting from the back.
+
+## Replacing the battery:
+
+The battery provides primary power whenever the system is unplugged.
+
+**Part numbers:**
+- The battery's model number is `X580BAT-8-98`.
+- The battery's original part number is `6-87-X580S-94J01`.
+- Third-party battery sellers may list one or both of these numbers, and may offer other compatible part numbers with the same model number. You can also [contact System76](https://support.system76.com) to purchase a replacement battery.
+
+**Tools required:** Cross-head (Phillips) screwdriver  
+**Time estimate:** 10 minutes  
+**Difficulty:** Easy <span style="color:green;">●</span>  
+
+### Steps to replace the battery:
+
+1. Follow the steps above to [remove the bottom cover](#removing-the-bottom-cover).
+2. Remove the four screws along the top of the battery.
+
+![Battery screws](./img/battery.webp)
+
+3. Unplug the white connector connecting the battery to the motherboard.
+4. Remove the battery, starting from the top edge with screw holes.
+5. When putting in the new battery, start with the plastic tabs along the bottom edge (opposite from the screw holes.)
+6. When plugging in the new battery, the red wire on the connector goes on the left, and the black wire goes on the right.
+
+## Replacing the RAM:
+
+The Bonobo WS 16 supports up to 192GB (4x48GB) of DDR5 SO-DIMMs running in dual-channel configuration at 5600MHz. The supported configurations are two or four SO-DIMMs (one or three SO-DIMMs are not supported configurations). If you've purchased new RAM, need to replace your RAM, or are reseating your RAM, follow these steps.
+
+**Tools required:** Cross-head (Phillips) screwdriver  
+**Time estimate:** 10 minutes  
+**Difficulty:** Easy <span style="color:green;">●</span>  
+
+### Steps to replace the RAM:
+
+1. Follow the steps above to [remove the bottom cover](#removing-the-bottom-cover).
+2. Press the small tabs on both sides of the RAM apart from each other simultaneously. The RAM should spring up to an angle.
+
+![RAM removal](./img/ram-slots.webp)
+
+3. Remove the RAM from the slot.
+4. Insert the new RAM (or reseat the existing RAM) by placing it in the keyed slot and pressing down on the RAM until it clicks into place.
+    - Either two or four SO-DIMMs (RAM sticks) are required. Using one or three SO-DIMMs is not supported.
+    - If you're installing only two SO-DIMMs, place them on top of each other (within the same colored box as shown above)-- i.e. in slots 1 and 2 (highlighted yellow), *or* in slots 3 and 4 (highlighted cyan).
+
+## Replacing an M.2/NVMe SSD:
+
+This model supports up to three M.2 SSDs. All M.2 slots are size 2280 and support PCIe NVMe Generation 4.
+
+**Tools required:** Cross-head (Phillips) screwdriver  
+**Time estimate:** 10 minutes  
+**Difficulty:** Easy <span style="color:green;">●</span>  
+
+### Steps to replace the M.2 drive:
+
+1. Follow the steps above to [remove the bottom cover](#removing-the-bottom-cover).
+2. Unscrew the retainer screw opposite the M.2 slot.
+
+![M.2 slots](./img/m2-slots.webp)
+
+3. Remove the existing M.2 drive by pulling it out of the slot.
+4. Insert the new M.2 drive into the slot and hold it in place.
+5. Replace the retainer screw.
+
+## Replacing the wireless card:
+
+Your Bonobo WS's WiFi and Bluetooth are both handled by the same module. It is a standard M.2 2230 slot with PCIe and USB interfaces (E-key).
+
+**Part numbers:**
+- Default wireless card: Intel `BE200`
+
+**Tools required:** Cross-head (Phillips) screwdriver  
+**Time estimate:** 10 minutes  
+**Difficulty:** Medium <span style="color:orange;">●</span>  
+
+### Steps to replace the WiFi/Bluetooth module:
+
+1. Follow the steps above to [remove the bottom cover](#removing-the-bottom-cover) and [remove the M.2 SSD from slot 4](#replacing-an-m2nvme-ssd) (if installed).
+2. Unscrew the wireless card screw holding the card and its wire bracket in place.
+    - The card will lift up at an angle once unscrewed.
+
+![Wireless card screw](./img/wireless-card-screw.webp)
+
+3. Remove the metal bracket that holds the wires onto the card.
+4. Gently remove the two antennas (highlighted red below) by pulling them up and away from the wireless card.
+
+![Wireless card antennas](./img/wireless-card-antennas.webp)
+
+5. Remove the card from the M.2 slot.
+6. Insert the new wireless card into the M.2 slot at an angle.
+7. Hold the card down and attach the two antennas by aligning the circular fittings and pressing onto the wireless card. The connectors will snap into place. _Use caution when attaching the connectors; the pins can bend, break, or snap._
+8. Replace the metal bracket and the retaining screw.
+9. Replace the M.2 SSD in slot 4 (if necessary) and bottom panel.
+
+## Replacing the CMOS battery:
+
+The CMOS battery supplies power to the system's CMOS chip. UEFI settings and the comptuer's hardware clock are stored on the CMOS. If your system doesn't boot, you can reset the CMOS to force a low-level hardware reset. If your clock is constantly resetting, it's likely your CMOS battery needs to be replaced.
+
+**Warning (ingestion hazard):** Keep batteries out of reach of children. Death or serious injury can occur if ingested. If a battery is suspected to be swallowed or inserted inside any part of the body, seek immediate medical attention. In the US, you can also call the National Battery Ingestion Hotline for guidance: [+1 (800) 498-8666](tel:18004988666)
+
+**Part numbers:**
+- The CMOS battery is a standard 3V KTS CR2032W battery.
+
+**Tools required:** Cross-head (Phillips) screwdriver    
+**Time estimate:** 10 minutes    
+**Difficulty:** Easy <span style="color:green;">●</span>
+
+### Steps to replace the CMOS battery:
+
+1. Follow the steps above to [remove the bottom cover](#removing-the-bottom-cover).
+    - If you're clearing the CMOS, also [unplug the main battery](#replacing-the-battery).
+2. Unplug the white connector that connects the CMOS battery to the motherboard's `J_RTC1` port (near SSD slot 2).
+    - If you're replacing the battery, gently pull it up from where it's stuck to the case.
+
+![CMOS battery](./img/cmos-battery.webp)
+
+3. To clear the CMOS, open the lid of the machine and hold down the power button for at least 15 seconds to discharge any residual energy in the system.
+4. Re-connect the CMOS battery and the main battery.
+5. Power up the Bonobo WS. The system may power itself off and on after initial boot; this is normal behavior when the CMOS has been reset.
+
+## Replacing the speakers:
+
+The system has three bottom-firing speakers, which can be removed and replaced individually.
+
+**Part numbers:**
+- Subwoofer: 
+- Left speaker: `6-23-5X580-0L2`
+- Right speaker: `6-23-5X580-0R2`
+
+**Tools required:** Cross-head (Phillips) screwdriver    
+**Time estimate:** 10 minutes    
+**Difficulty:** Medium <span style="color:orange;">●</span>
+
+### Steps to replace the subwoofer:
+
+1. Follow the steps above to [remove the bottom cover](#removing-the-bottom-cover).
+2. Remove the four silver screws holding the subwoofer onto the heatsink.
+
+![Subwoofer screws & connector](./img/speaker-subwoofer.webp)
+
+3. Unplug the subwoofer from the `J_SPKL5` port on the motherboard and remove it from the chassis.
+4. Replace the subwoofer and bottom cover.
+
+### Steps to replace the left and right speakers:
+
+1. Follow the steps above to [remove the bottom cover](#removing-the-bottom-cover).
+    - For the right speaker, also [remove the M.2 SSD from slot 4](#replacing-an-m2nvme-ssd) (if installed).
+2. Pull the speaker(s) off of the plastic posts.
+
+![Audio daughterboard](./img/speakers-left-right.webp)
+
+3. Disconnect the speaker connector(s) from the motherboard.
+    - The left speaker (pictured on the right above) connects to `J_SPK1`.
+    - The right speaker (pictured on the left) connects to `J_SPK2`.
+4. Replace the speaker(s) and bottom cover.
+
+## Replacing the cooling system:
+
+The Bonobo WS 16 has a single heatsink assembly with two fans. This assembly cools the CPU and GPU.
+
+If the fans become noisy and cleaning them out doesn't fix the issue, you may need a new fan. [Contact support](https://support.system76.com) to start a warranty claim or parts purchase.
+
+Depending on your climate and the age of the machine, it may be necessary to apply new thermal paste between the CPU/GPU and the heatsink. Thermal paste helps facilitate effective heat transfer between the CPU/GPU and the cooling equipment. These instructions can also be used in the unlikely event your heatsink needs to be replaced.
+
+**Part numbers:**
+- Heatsink/fan assembly: `6-31-X580N-101`
+- Individual fans (may not be available separately):
+    - Left fan: Yingfan `NA901212HHT4B10001 DX1`
+    - Right fan: Yingfan `NB901212HHT4B0001 DX2`
+
+**Tools required:** Cross-head (Phillips) screwdriver  
+**Time estimate:** 15 minutes  
+**Difficulty:** High <span style="color:red;">●</span>  
+
+### Steps to replace the heatsink/thermal paste:
+
+1. Follow the steps above to [remove the bottom cover](#removing-the-bottom-cover) and [remove the SSD from slot 1](#replacing-an-m2nvme-ssd) (if installed).
+2. [Disconnect the subwoofer](#steps-to-replace-the-subwoofer) from the motherboard's `J_SPKL5` header.
+    - You can optionally remove the subwoofer. In the photo below, the subwoofer has been removed to better illustrate the location of the heatsink screws.
+3. Remove the fourteen heatsink and fan screws in order of the stamped numbers, starting with #1, then #2, and continuing until you have removed #14.
+    - Screws #1-#12 are held captive, and will not completely detatch from the heatsink/fans.
+    - Screws #13 and #14 are slightly smaller than the rest of the screws, and are not held captive.
+    - Do not remove the smaller screws holding the fan covers onto the fans.
+
+![Thermal screws](./img/thermal-system.webp)
+
+4. Remove any clear tape covering the fan wires.
+5. Unplug the black fan connectors from the motherboard's fan headers, `J_VGAFAN1` (highlighted red above) and `J_CPUFAN1` (highlighted green).
+6. Remove the heatsink/fans from the case, being careful not to bend the heatsink pipes. It may take some pressure to break the seal of the thermal paste.
+7. Using a paper towel, remove the existing thermal paste from the CPU, GPU, VRAM chips, and heatsink. You may also use a small amount of rubbing alcohol if the old paste is dried or difficult to remove.
+    - In the below photos, the subwoofer is screwed into the heatsink, so its cable is visible in addition to the fan cables.
+
+![Thermal paste removal](./img/thermal-paste-removal.webp)
+
+8. Apply a small line of thermal paste directly onto the CPU chip, the GPU chip, and the eight VRAM chips.
+
+![Thermal paste application](./img/thermal-paste-application.webp)
+
+9. Carefully replace the heatsink.
+    - Make sure the tab on the end of the keyboard adhesive strip (highlighted green above) is fed through the slot in the heatsink (next to the GPU fan).
+10. Tighten the fan and heatsink screws from #1 to #12, then reinstall the final two heatsink screws (#13 and #14).
+11. Plug the black fan connectors back into the motherboard and (optionally) replace the clear tape holding down the CPU fan's cable.
+
+## Replacing the keyboard:
+
+The keyboard includes per-key RGB LED backlighting, and can be replaced using the instructions below.
+
+**Warning:** Removing the keyboard may cause permanent aesthetic damage to the underside of the keyboard, particularly if the adhesive strip is not fully removed first. Removal is not recommended unless the keyboard is malfunctioning.
+
+**Part numbers:**
+- Keyboard:
+    - Model number: `6-X580[D]WNT-G-KB-LPK-US`, also known as `CVM18H93US9430FA`
+    - Part number: `6-80-PC510-013-1MD`
+
+**Tools required:** Cross-head (Phillips) screwdriver; tweezers (optional)  
+**Time estimate:** 10 minutes  
+**Difficulty:** High <span style="color:red;">●</span>  
+
+### Steps to replace the keyboard:
+
+1. Follow the steps above to [remove the bottom cover](#removing-the-bottom-cover).
+2. Pull the keyboard adhesive out of the machine to detatch it from the keyboard.
+    - The adhesive strip access point is highlighted green below.
+    - If the end of the keyboard adhesive strip is tucked behind the fan, it can be pulled out using tweezers or a small screwdriver, or the [thermal system can be removed](#replacing-the-cooling-system) to expose it.
+        - Replacing the thermal paste is recommended if the thermal system is removed.
+    - If the adhesive strip breaks, remove as much of it as possible. The keyboard can be reinstalled without the adhesive strip.
+
+![Keyboard adhesive & push point](./img/keyboard-adhesive.webp)
+
+3. Open the lid slightly and place the machine on its side.
+4. Push a screwdriver into the keyboard push point (highlighted red above) until the keyboard pops out.
+
+![Keyboard push point](./img/keyboard-push-point.webp)
+
+5. Set the machine back down and raise the keyboard away from the chassis. The largest ribbon cable is for the keyboard, while the smaller ribbon cables are for the keyboard backlight.
+
+![Keyboard ribbons](./img/keyboard-ribbons.webp)
+
+6. Flip the black latches upwards to free the ribbon cables.
+7. Pull the ribbon cables out of the connectors.
+8. Remove the keyboard and replace it with the new one.
+9. Carefully slide all three ribbon cables into their connectors.
+10. Flip the black latches back into place to secure the ribbon cables.
+11. (Optional) Replace the keyboard adhesive strip on the chassis, sliding the tab at the end through the adhesive strip access point.
+12. Place the keyboard back into position, starting with the tabs on the bottom edge.
+13. Secure the rest of the keyboard by pressing down on each of its edges.
+14. Turn the machine lid-side down again.
+15. Replace the bottom cover.

--- a/src/models/bonw16/repairs.md
+++ b/src/models/bonw16/repairs.md
@@ -60,7 +60,16 @@ The battery provides primary power whenever the system is unplugged.
 
 ## Replacing the RAM:
 
-The Bonobo WS 16 supports up to 192GB (4x48GB) of DDR5 SO-DIMMs running in dual-channel configuration at 5600MHz. The supported configurations are two or four SO-DIMMs (one or three SO-DIMMs are not supported configurations). If you've purchased new RAM, need to replace your RAM, or are reseating your RAM, follow these steps.
+The Bonobo WS 16 supports up to 192GB (4x48GB) of DDR5 SO-DIMMs running in dual-channel configuration. The RAM speed depends on the rank and number of SO-DIMMs:
+
+- Any number of single-rank SO-DIMMs will run at a speed of 4400MHz.
+    - The 2x16GB (32GB total) factory configuration runs at this speed.
+- A single dual-rank SO-DIMM will run at 4400MHz.
+    - This configuration is not recommended because running in single-channel mode will result in lower performance than the equivalent capacity running in dual-channel mode at a slightly lower speed.
+- More than one dual-rank SO-DIMM will run at 4000MHz.
+    - All other factory configurations run at this speed.
+
+If you've purchased new RAM, need to replace your RAM, or are reseating your RAM, follow these steps.
 
 **Tools required:** Cross-head (Phillips) screwdriver  
 **Time estimate:** 10 minutes  
@@ -158,7 +167,7 @@ The CMOS battery supplies power to the system's CMOS chip. UEFI settings and the
 The system has three bottom-firing speakers, which can be removed and replaced individually.
 
 **Part numbers:**
-- Subwoofer: 
+- Subwoofer: `6-23-5X580-0W2`
 - Left speaker: `6-23-5X580-0L2`
 - Right speaker: `6-23-5X580-0R2`
 

--- a/src/models/bonw16/repairs.md
+++ b/src/models/bonw16/repairs.md
@@ -193,9 +193,11 @@ The system has three bottom-firing speakers, which can be removed and replaced i
 
 The Bonobo WS 16 has a single heatsink assembly with two fans. This assembly cools the CPU and GPU.
 
-If the fans become noisy and cleaning them out doesn't fix the issue, you may need a new fan. [Contact support](https://support.system76.com) to start a warranty claim or parts purchase.
+If the fans become noisy and cleaning them out doesn't fix the issue, you may need a new fan. [Contact support](https://support.system76.com) to start a warranty claim or parts purchase. These instructions can also be used if physical damage to the heatsink necessitates its replacement.
 
-Depending on your climate and the age of the machine, it may be necessary to apply new thermal paste between the CPU/GPU and the heatsink. Thermal paste helps facilitate effective heat transfer between the CPU/GPU and the cooling equipment. These instructions can also be used in the unlikely event your heatsink needs to be replaced.
+Thermal paste helps facilitate effective heat transfer between the CPU/GPU and the cooling equipment; depending on your climate and the age of the machine, replacing the thermal paste may improve cooling performance. The thermal paste should generally be replaced whenever the heatsink is removed.
+
+Thermal putty (thicker than thermal paste) is used to bridge the gap between the VRAM chips and the heatsink. Replacing the thermal putty is optional when removing the heatsink. System76 suggests [Thermal Grizzly Putty Basic](https://www.thermal-grizzly.com/en/tg-putty/s-tg-p-b-030) (available at various retailers) or a similar alternative.
 
 **Part numbers:**
 - Heatsink/fan assembly: `6-31-X580N-101`
@@ -203,7 +205,7 @@ Depending on your climate and the age of the machine, it may be necessary to app
     - Left fan: Yingfan `NA901212HHT4B10001 DX1`
     - Right fan: Yingfan `NB901212HHT4B0001 DX2`
 
-**Tools required:** Cross-head (Phillips) screwdriver  
+**Tools required:** Cross-head (Phillips) screwdriver, thermal putty spreader (flat plastic tool)  
 **Time estimate:** 15 minutes  
 **Difficulty:** High <span style="color:red;">●</span>  
 
@@ -222,12 +224,15 @@ Depending on your climate and the age of the machine, it may be necessary to app
 4. Remove any clear tape covering the fan wires.
 5. Unplug the black fan connectors from the motherboard's fan headers, `J_VGAFAN1` (highlighted red above) and `J_CPUFAN1` (highlighted green).
 6. Remove the heatsink/fans from the case, being careful not to bend the heatsink pipes. It may take some pressure to break the seal of the thermal paste.
-7. Using a paper towel, remove the existing thermal paste from the CPU, GPU, VRAM chips, and heatsink. You may also use a small amount of rubbing alcohol if the old paste is dried or difficult to remove.
+7. Using a paper towel, remove the existing thermal paste from the CPU, GPU, and heatsink. You may also use a small amount of rubbing alcohol if the old paste is dried or difficult to remove.
     - In the below photos, the subwoofer is screwed into the heatsink, so its cable is visible in addition to the fan cables.
+    - You can optionally remove the thermal putty from the eight VRAM chips surrounding the GPU chip if you have replacement thermal putty to install.
 
 ![Thermal paste removal](./img/thermal-paste-removal.webp)
 
-8. Apply a small line of thermal paste directly onto the CPU chip, the GPU chip, and the eight VRAM chips.
+8. Apply a small line of thermal paste directly onto the CPU chip and the GPU chip.
+    - If you're also replacing the thermal putty, apply the new putty to the eight VRAM chips.
+    - If you aren't replacing the thermal putty, scoop the existing putty (from the VRAM chip and the corresponding location on the heatsink) into the center of each VRAM chip using a flat plastic tool.
 
 ![Thermal paste application](./img/thermal-paste-application.webp)
 

--- a/src/models/oryp11/repairs.md
+++ b/src/models/oryp11/repairs.md
@@ -139,11 +139,13 @@ The CMOS battery supplies power to the system's CMOS chip. UEFI settings and the
 
 The Oryx Pro 11 uses two fans and a heatsink manufactured as a single assembly. The part number for the complete assembly is YINGFAN `6-31-PE60N-102`. The part number for the left fan is WINMA `EFC-92091S2-0BH`; the part number for the right fan is WINMA `EFC-90091S2-0BH`.
 
-If the CPU/GPU fans become noisy and cleaning them out doesn't fix the issue, you may need a new fan. [Contact support](https://support.system76.com) to start a warranty claim or parts purchase.
+If the fans become noisy and cleaning them out doesn't fix the issue, you may need a new fan. [Contact support](https://support.system76.com) to start a warranty claim or parts purchase. These instructions can also be used if physical damage to the heatsink necessitates its replacement.
 
-Thermal paste helps facilitate heat transfer between the CPU/GPU and the cooling equipment. Depending on your climate and the age of the machine, replacing the thermal paste between the CPU/GPU and the heatsink may help the system run cooler. It's recommended to replace the thermal paste whenever the heatsink is removed.
+Thermal paste helps facilitate effective heat transfer between the CPU/GPU and the cooling equipment; depending on your climate and the age of the machine, replacing the thermal paste may improve cooling performance. The thermal paste should generally be replaced whenever the heatsink is removed.
 
-**Tools required:** Cross-head (Phillips) screwdriver  
+Thermal putty (thicker than thermal paste) is used to bridge the gap between the VRAM chips and the heatsink. Replacing the thermal putty is optional when removing the heatsink. System76 suggests [Thermal Grizzly Putty Basic](https://www.thermal-grizzly.com/en/tg-putty/s-tg-p-b-030) (available at various retailers) or a similar alternative.
+
+**Tools required:** Cross-head (Phillips) screwdriver, thermal putty spreader (flat plastic tool)  
 **Time estimate:** 40 minutes  
 **Difficulty:** High <span style="color:red;">●</span>  
 
@@ -158,12 +160,15 @@ Thermal paste helps facilitate heat transfer between the CPU/GPU and the cooling
 
 4. Unplug the two fan connectors from the motherboard (highlighted red above).
 5. Remove the heatsink/fans from the case, being careful not to bend the heatsink pipes. It may take some pressure to break the seal of the thermal paste.
-6. Using a paper towel, remove the existing thermal paste from the CPU chips, GPU chip, and surrounding components, as well as the corresponding points on the heat sink. You may also use a small amount of rubbing alcohol if the old paste is dried or difficult to remove.
-    - Some thermal paste may already be on the motherboard around the VRAM chips, or may get onto the motherboard while cleaning the paste off of the chips. Thermal paste is typically not conductive; it's safer to leave excess paste on the board than to risk damaging the board with rough removal.
+6. Using a paper towel, remove the existing thermal paste from the CPU chips and the GPU chip, as well as the corresponding points on the heat sink. You may also use a small amount of rubbing alcohol if the old paste is dried or difficult to remove.
+    - You can optionally remove the thermal putty from the three Samsung VRAM chips and the twelve `R15` chips surrounding the GPU chip if you have replacement thermal putty to install.
+    - Some thermal paste and/or putty may already be on the motherboard around the VRAM chips, or may get onto the motherboard while cleaning the paste/putty off of the chips. Thermal paste and putty is typically not conductive; it's safer to leave excess paste on the board than to risk damaging the board with rough removal.
 
 ![Thermal paste removal](./img/thermal-paste-removal.webp)
 
-7. Apply a small line of thermal paste directly onto both CPU chips, the GPU chip, the three Samsung VRAM chips, and the twelve `R15` chips.
+7. Apply a small line of thermal paste directly onto both CPU chips and the GPU chip.
+    - If you're also replacing the thermal putty, apply the new putty to the three Samsung VRAM chips and the twelve `R15` chips.
+    - If you aren't replacing the thermal putty, scoop the existing putty (from the chip and the corresponding location on the heatsink) into the center of each VRAM and `R15` chip using a flat plastic tool.
 
 ![Thermal paste application](./img/thermal-paste-application.webp)
 

--- a/src/models/oryp12/repairs.md
+++ b/src/models/oryp12/repairs.md
@@ -149,9 +149,13 @@ The CMOS battery supplies power to the system's CMOS chip. UEFI settings and the
 
 ## Replacing the cooling system:
 
-The Oryx Pro 12 uses two fans and a heatsink manufactured as a single assembly. If the CPU/GPU fans become noisy and cleaning them out doesn't fix the issue, you may need a new fan. [Contact support](https://support.system76.com) to start a warranty claim or parts purchase.
+The Oryx Pro 12 uses two fans and a heatsink manufactured as a single assembly.
 
-Thermal paste helps facilitate heat transfer between the CPU/GPU and the cooling equipment. Depending on your climate and the age of the machine, replacing the thermal paste between the CPU/GPU and the heatsink may help the system run cooler. It's recommended to replace the thermal paste whenever the heatsink is removed.
+If the fans become noisy and cleaning them out doesn't fix the issue, you may need a new fan. [Contact support](https://support.system76.com) to start a warranty claim or parts purchase. These instructions can also be used if physical damage to the heatsink necessitates its replacement.
+
+Thermal paste helps facilitate effective heat transfer between the CPU/GPU and the cooling equipment; depending on your climate and the age of the machine, replacing the thermal paste may improve cooling performance. The thermal paste should generally be replaced whenever the heatsink is removed.
+
+Thermal putty (thicker than thermal paste) is used to bridge the gap between the VRAM chips and the heatsink. Replacing the thermal putty is optional when removing the heatsink. System76 suggests [Thermal Grizzly Putty Basic](https://www.thermal-grizzly.com/en/tg-putty/s-tg-p-b-030) (available at various retailers) or a similar alternative.
 
 **Part numbers:**
 - Heatsink/fan assembly: YINGFAN `6-31-PE6SN-102`
@@ -159,7 +163,7 @@ Thermal paste helps facilitate heat transfer between the CPU/GPU and the cooling
     - Left fan: WINMA `ECG-82090S2-0AH`
     - Right fan: WINMA `ECG-85090S1-0AH`
 
-**Tools required:** Cross-head (Phillips) screwdriver  
+**Tools required:** Cross-head (Phillips) screwdriver, thermal putty spreader (flat plastic tool)  
 **Time estimate:** 40 minutes  
 **Difficulty:** High <span style="color:red;">●</span>  
 
@@ -175,12 +179,15 @@ Thermal paste helps facilitate heat transfer between the CPU/GPU and the cooling
 
 4. Unplug the two fan connectors from the motherboard (highlighted red above).
 5. Remove the heatsink/fans from the case, being careful not to bend the heatsink pipes. It may take some pressure to break the seal of the thermal paste.
-6. Using a paper towel, remove the existing thermal paste from the CPU chips, GPU chip, and surrounding components, as well as the corresponding points on the heat sink. You may also use a small amount of rubbing alcohol if the old paste is dried or difficult to remove.
-    - Some thermal paste may already be on the motherboard around the VRAM chips, or may get onto the motherboard while cleaning the paste off of the chips. Thermal paste is typically not conductive; it's safer to leave excess paste on the board than to risk damaging the board with rough removal.
+6. Using a paper towel, remove the existing thermal paste from the CPU chips and the GPU chip, as well as the corresponding points on the heat sink. You may also use a small amount of rubbing alcohol if the old paste is dried or difficult to remove.
+    - You can optionally remove the thermal putty from the four Samsung VRAM chips surrounding the GPU chip and the seven `R15` chips forming an "L" shape around the CPU if you have replacement thermal putty to install.
+    - Some thermal paste and/or putty may already be on the motherboard around the VRAM chips, or may get onto the motherboard while cleaning the paste/putty off of the chips. Thermal paste and putty is typically not conductive; it's safer to leave excess paste on the board than to risk damaging the board with rough removal.
 
 ![Thermal paste removal](./img/thermal-paste-removal.webp)
 
-7. Apply a small line of thermal paste directly onto both CPU chips, the GPU chip, the four Samsung VRAM chips, and the seven `R15` chips forming an "L" shape around the CPU.
+7. Apply a small line of thermal paste directly onto both CPU chips and the GPU chip.
+    - If you're also replacing the thermal putty, apply the new putty to the four Samsung VRAM chips and the seven `R15` chips.
+    - If you aren't replacing the thermal putty, scoop the existing putty (from the chip and the corresponding location on the heatsink) into the center of each VRAM and `R15` chip using a flat plastic tool.
 
 ![Thermal paste application](./img/thermal-paste-application.webp)
 

--- a/src/models/serw13/repairs.md
+++ b/src/models/serw13/repairs.md
@@ -138,11 +138,13 @@ This model supports up to two M.2 SSDs. Both M.2 slots are size 2280 and support
 
 The Serval WS 13 has a single heatsink assembly with two fans. This assembly cools the CPU and GPU.
 
-If the fans become noisy and cleaning them out doesn't fix the issue, you may need a new fan. [Contact support](https://support.system76.com) to start a warranty claim or parts purchase.
+If the fans become noisy and cleaning them out doesn't fix the issue, you may need a new fan. [Contact support](https://support.system76.com) to start a warranty claim or parts purchase. These instructions can also be used if physical damage to the heatsink necessitates its replacement.
 
-Depending on your climate and the age of the machine, it may be necessary to apply new thermal paste between the CPU/GPU and the heatsink. Thermal paste helps facilitate effective heat transfer between the CPU/GPU and the cooling equipment. These instructions can also be used in the unlikely event your heatsink needs to be replaced.
+Thermal paste helps facilitate effective heat transfer between the CPU/GPU and the cooling equipment; depending on your climate and the age of the machine, replacing the thermal paste may improve cooling performance. The thermal paste should generally be replaced whenever the heatsink is removed.
 
-**Tools required:** Cross-head (Phillips) screwdriver  
+Thermal putty (thicker than thermal paste) is used to bridge the gap between the VRAM chips and the heatsink. Replacing the thermal putty is optional when removing the heatsink. System76 suggests [Thermal Grizzly Putty Basic](https://www.thermal-grizzly.com/en/tg-putty/s-tg-p-b-030) (available at various retailers) or a similar alternative.
+
+**Tools required:** Cross-head (Phillips) screwdriver, thermal putty spreader (flat plastic tool)  
 **Time estimate:** 15 minutes  
 **Difficulty:** High <span style="color:red;">●</span>  
 
@@ -157,11 +159,14 @@ Depending on your climate and the age of the machine, it may be necessary to app
 
 3. Unplug the white fan connectors from the motherboard.
 4. Remove the heatsink/fans from the case, being careful not to bend the heatsink pipes. It may take some pressure to break the seal of the thermal paste.
-5. Using a paper towel, remove the existing thermal paste from the CPU, GPU, VRAM chips, and heatsink. You may also use a small amount of rubbing alcohol if the old paste is dried or difficult to remove.
+5. Using a paper towel, remove the existing thermal paste from the CPU, GPU, and heatsink. You may also use a small amount of rubbing alcohol if the old paste is dried or difficult to remove.
+    - You can optionally remove the thermal putty from the four VRAM chips surrounding the GPU chip if you have replacement thermal putty to install.
 
 ![Thermal paste removal](./img/thermal-paste-removal.webp)
 
-6. Apply a small line of thermal paste directly onto the CPU chip, GPU chip, and VRAM chips.
+6. Apply a small line of thermal paste directly onto the CPU chip and the GPU chip.
+    - If you're also replacing the thermal putty, apply the new putty to the four VRAM chips.
+    - If you aren't replacing the thermal putty, scoop the existing putty (from the VRAM chip and the corresponding location on the heatsink) into the center of each VRAM chip using a flat plastic tool.
 
 ![Thermal paste application](./img/thermal-paste-application.webp)
 


### PR DESCRIPTION
This adds port diagrams, component/connector overviews, and a repair manual for the Bonobo WS 16 (bonw16).

Also made a small adjustment to wording in the bonw15 section (it has three ribbon cables for its keyboard, so the word "both" shouldn't have been used to refer to them).