### PR TITLE
darp11 (external overview): Update captions on lid photo

### DIFF
--- a/src/models/darp11/img/lid.webp
+++ b/src/models/darp11/img/lid.webp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:932dbd5f727b8a15a8caf1449aadd40d985c880ad37ecc09bcd3580ae53ff662
-size 568688
+oid sha256:584d394bf9b73b7c4994d02a6e708509f98df005f91d028013f402c4414882fa
+size 913910


### PR DESCRIPTION
This updates the captions on the darp11 lid photo, which was reused from the darp10 section but didn't have its captions updated in https://github.com/system76/tech-docs/pull/300.