### PR TITLE
elan1-r1 (specs): Correct manufacturer model number & link

### DIFF
--- a/src/models/elan1-r1/README.md
+++ b/src/models/elan1-r1/README.md
@@ -4,10 +4,8 @@
 
 The System76 Eland 1U is a rack-mounted server. The `R1` model code indicates the first revision based on an AMD platform. This model has the following specifications:
 
-- Chassis (depending on configuration)
-    - [Gigabyte R152-Z30 (Rev. A00)](https://www.gigabyte.com/Enterprise/Rack-Server/R152-Z32-rev-A00)
-    - [Gigabyte R152-Z31 (Rev. A00)](https://www.gigabyte.com/Enterprise/Rack-Server/R152-Z31-rev-A00)
-    - [Gigabyte R152-Z32 (Rev. A00)](https://www.gigabyte.com/Enterprise/Rack-Server/R152-Z32-rev-A00)
+- Chassis
+    - [Gigabyte R152-Z30 (Rev. A00)](https://www.gigabyte.com/Enterprise/Rack-Server/R152-Z30-rev-A00)
 - CPU options
     - Supports 1x AMD EPYC 7003-series processor
 - Memory


### PR DESCRIPTION
Corrected the URL for the Z30 model number. A Blazer search shows the elan1-r1 only ever shipped with the Z30 (and the Z30 is what the rest of these specs are for, particularly the storage section), so removed the Z31 and Z32 as options.

I can update this PR with any additional corrections if QA wants to review all the new server sections now, or we can do it piecemeal.