### PR TITLE
pang15 (specs): Correct dimensions

### DIFF
--- a/src/models/pang15/README.md
+++ b/src/models/pang15/README.md
@@ -63,4 +63,4 @@ The System76 Pangolin is a laptop with the following specifications:
         - Does not support Thunderbolt
     - 3x USB 3.2 Gen 1 Type-A
 - Dimensions
-    - 1.80cm x 35.06cm x 24.06cm, 1.73kg
+    - 1.8cm x 35.6cm x 24.6cm, 1.73kg


### PR DESCRIPTION
Levi took the following measurements in the lab:

![IMG_20250902_145848_536](https://github.com/user-attachments/assets/b358787f-8d90-4c86-8084-54550f890cd0)

![IMG_20250902_150000](https://github.com/user-attachments/assets/b988951e-ce35-4f30-9520-506736b75bd8)

Assuming it was typo'd when it was input into the sales page where I pulled the numbers from.