### PR TITLE
thelio-major-r5-n3 (specs): Add 1200W PSU info

### DIFF
--- a/src/models/thelio-major-r5-n3/README.md
+++ b/src/models/thelio-major-r5-n3/README.md
@@ -75,11 +75,17 @@ The System76 Thelio Major is a desktop with the following specifications:
     - Wi-Fi 6E + Bluetooth 5.2 ([Intel AX211](https://ark.intel.com/content/www/us/en/ark/products/204837/intel-wi-fi-6e-ax211-gig.html))
 - Power
     - C13 power cord
-    - 1000W PSU
+    - PSU wattage (depending on ship date):
+        - After October 2025: 1200W PSU
+        - Before October 2025: 1000W PSU
     - 80+ Gold Efficiency
     - Tested with the following PSU models (may ship with other tested models):
-        - [XPG Core Reactor II 1000W](https://www.xpg.com/us/xpg/pc-components-core-reactor-ii?tab=spec)
-        - [Be Quiet! Pure Power 12M 1000W](https://www.bequiet.com/en/powersupply/4161)
+        - After October 2025:
+            - XPG Core Shift II 1200W
+        - From July 2024 until October 2025:
+            - [XPG Core Reactor II 1000W](https://www.xpg.com/us/xpg/pc-components-core-reactor-ii?tab=spec)
+        - Before July 2024:
+            - [Be Quiet! Pure Power 12M 1000W](https://www.bequiet.com/en/powersupply/4161)
 - Sound
     - Back:
         - 3.5mm mic in

--- a/src/models/thelio-major-r5-n3/repairs.md
+++ b/src/models/thelio-major-r5-n3/repairs.md
@@ -443,8 +443,9 @@ If you've purchased new RAM, need to replace your RAM, or are reseating your RAM
 The power supply unit (PSU) can be replaced with another unit of the same model.
 
 **Part numbers:**
-- The default PSU in units shipped after July 2024 is the [XPG Core Reactor II (1000W)](https://www.xpg.com/us/xpg/pc-components-core-reactor-ii).
-- The default PSU in older units is the [Be Quiet! Pure Power 12 M 1000W (L12-M-1000W)](https://www.bequiet.com/en/powersupply/4161).
+- The default PSU in units shipped after October 2025 is the XPG Core Shift II (1200W).
+- The default PSU in units shipped from July 2024 until October 2025 is the [XPG Core Reactor II (1000W)](https://www.xpg.com/us/xpg/pc-components-core-reactor-ii).
+- The default PSU in units shipped before July 2024 is the [Be Quiet! Pure Power 12 M 1000W (L12-M-1000W)](https://www.bequiet.com/en/powersupply/4161).
 
 **Tools required:** Cross-head (Phillips) screwdriver  
 **Time estimate:** 45 minutes  


### PR DESCRIPTION
Also added the existing info about the previous PSU split from the repairs page on the main specs page, since it seemed like it made sense to include it there now.