### PR TITLE
pang12/13/14 (specs): Add alternative RAM SKU & correct chip count

### DIFF
--- a/src/models/pang12/README.md
+++ b/src/models/pang12/README.md
@@ -26,8 +26,10 @@ The System76 Pangolin is a laptop with the following specifications:
         - 1x HDMI 2.0
         - 1x DisplayPort 1.4 over USB-C
 - Memory
-    - 32GB LPDDR5 (on-board) @ 6400 MHz
-        - 16x [Micron MT62F2G32D8DR-031](https://www.micron.com/products/memory/dram-components/lpddr5/part-catalog/part-detail/mt62f2g32d8dr-031-wt-b) (2GB each)
+    - 32GB (4x8GB) LPDDR5 (on-board) @ 6400 MHz
+        - [Micron MT62F2G32D8DR-031](https://www.micron.com/products/memory/dram-components/lpddr5/part-catalog/part-detail/mt62f2g32d8dr-031-wt-b)
+        - [SK Hynix H9JCNNNFA5MLYR-N6E](https://product.skhynix.com/products/dram/lpddr/lpddr5.go?appTypCd=APX02&treeNo=1054)
+        - ...or other equivalent.
 - Networking
     - Gigabit Ethernet
     - M.2 PCIe WiFi/Bluetooth

--- a/src/models/pang13/README.md
+++ b/src/models/pang13/README.md
@@ -26,8 +26,10 @@ The System76 Pangolin is a laptop with the following specifications:
         - 1x HDMI 2.0
         - 1x DisplayPort 1.4 over USB-C
 - Memory
-    - 32GB LPDDR5 (on-board) @ 6400 MHz
-        - 16x [Micron MT62F2G32D8DR-031](https://www.micron.com/products/memory/dram-components/lpddr5/part-catalog/part-detail/mt62f2g32d8dr-031-wt-b) (2GB each)
+    - 32GB (4x8GB) LPDDR5 (on-board) @ 6400 MHz
+        - [Micron MT62F2G32D8DR-031](https://www.micron.com/products/memory/dram-components/lpddr5/part-catalog/part-detail/mt62f2g32d8dr-031-wt-b)
+        - [SK Hynix H9JCNNNFA5MLYR-N6E](https://product.skhynix.com/products/dram/lpddr/lpddr5.go?appTypCd=APX02&treeNo=1054)
+        - ...or other equivalent.
 - Networking
     - Gigabit Ethernet
     - M.2 PCIe WiFi/Bluetooth

--- a/src/models/pang14/README.md
+++ b/src/models/pang14/README.md
@@ -26,8 +26,10 @@ The System76 Pangolin is a laptop with the following specifications:
         - 1x HDMI 2.0
         - 1x DisplayPort 1.4 over USB-C
 - Memory
-    - 32GB LPDDR5 (on-board) @ 6400 MHz
-        - 16x [Micron MT62F2G32D8DR-031](https://www.micron.com/products/memory/dram-components/lpddr5/part-catalog/part-detail/mt62f2g32d8dr-031-wt-b) (2GB each)
+    - 32GB (4x8GB) LPDDR5 (on-board) @ 6400 MHz
+        - [Micron MT62F2G32D8DR-031](https://www.micron.com/products/memory/dram-components/lpddr5/part-catalog/part-detail/mt62f2g32d8dr-031-wt-b)
+        - [SK Hynix H9JCNNNFA5MLYR-N6E](https://product.skhynix.com/products/dram/lpddr/lpddr5.go?appTypCd=APX02&treeNo=1054)
+        - ...or other equivalent.
 - Networking
     - Gigabit Ethernet
     - M.2 PCIe WiFi/Bluetooth


### PR DESCRIPTION
The RAM is four physical chips. I'm not sure what the 2G x32 "component config" on the Micron website is referring to (likely something smaller within the chips-- looks like possibly something to do with rank or channels according to [their part number explanation sheet](https://assets.micron.com/adobe/assets/urn:aaid:aem:4c7ee063-8a72-45c3-90c8-a0254083ccc7/original/as/numsdrammod.pdf)).

Added the SK Hynix SKU that many of our units have shipped with. I also saw some mention of a Samsung model in Slack history (didn't see a specific SKU), so I added the "or other equivalent" to be safe.

CC: @jklgrasso