### PR TITLE
darp10/11 (repairs): Show bottom panel & top case separation point

### DIFF
--- a/src/models/darp10/img/bottom-panel-removal.webp
+++ b/src/models/darp10/img/bottom-panel-removal.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:74f62e31666f328e8b75549b4837b9c10690a76c34e5a9b11d263f6a20f0c7c6
+size 257016

--- a/src/models/darp10/repairs.md
+++ b/src/models/darp10/repairs.md
@@ -39,6 +39,8 @@ Removing the cover is required to access the internal components. Prior to remov
     ![Bottom panel screws (darp10-b, 14")](./img/bottom-screws-14.webp)
 3. Pull the bottom panel off, starting from the hinges in the back.
 
+![Bottom panel removal](./img/bottom-panel-removal.webp)
+
 ## Replacing the RAM:
 
 The Darter Pro 10 supports up to 96GB (2x48GB) of DDR5 SO-DIMMs running at 5600MHz. If you've purchased new RAM, need to replace your RAM, or are reseating your RAM, follow these steps.

--- a/src/models/darp11/img/bottom-panel-removal.webp
+++ b/src/models/darp11/img/bottom-panel-removal.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a658e8abeb6c77dd6e37d803f5171123a38c3d2a05f389821beb9de98576ccca
+size 333938

--- a/src/models/darp11/repairs.md
+++ b/src/models/darp11/repairs.md
@@ -39,6 +39,8 @@ Removing the cover is required to access the internal components. Prior to remov
     ![Bottom panel screws (darp11-b, 14")](./img/bottom-screws-14.webp)
 3. Pull the bottom panel off, starting from the hinges in the back.
 
+![Bottom panel removal](./img/bottom-panel-removal.webp)
+
 ## Replacing the RAM:
 
 The Darter Pro 10 supports up to 96GB (2x48GB) of DDR5 SO-DIMMs running at 5600MHz. If you've purchased new RAM, need to replace your RAM, or are reseating your RAM, follow these steps.


### PR DESCRIPTION
Closes https://github.com/system76/tech-docs/issues/277.

This angle seemed to make sense since the instructions say to start at the back, and it shows that the part wraps down and isn't just a flat piece on the bottom.