### PR TITLE
meer9: Correct CU7 power adapter model number typo

### DIFF
--- a/src/models/meer9/README.md
+++ b/src/models/meer9/README.md
@@ -31,7 +31,7 @@ The System76 Meerkat is a desktop with the following specifications:
     - Core Ultra 7 model:
         - 120W (19V, 6.32A) DC-in port
             - Barrel size: 5.5mm (outer), 2.5mm (inner)
-        - Included AC adapter*: AcBel ADC017
+        - Included AC adapter*: AcBel ADC027
             - AC power cord type: IEC C5
     - Core Ultra 5 model:
         - 90W (19V, 4.74A) DC-in port


### PR DESCRIPTION
We noticed the model wasn't coming up as expected when searching it online, so we checked the actual adapter:

![IMG_20260408_132845_202](https://github.com/user-attachments/assets/8302742d-cabe-478e-9e05-0201a8dac199)
