### PR TITLE
launch_3b (external overview): Make more images transparent

### DIFF
--- a/src/models/launch_3b/external-overview.md
+++ b/src/models/launch_3b/external-overview.md
@@ -6,7 +6,7 @@
 
 ## Back overview:
 
-![Launch Ports](./img/ports-back.avif)
+<span class="text-on-transparency">![Launch Ports](./img/ports-back.avif)</span>
 
 ## Box contents overview:
 

--- a/src/models/launch_3b/img/box-contents.avif
+++ b/src/models/launch_3b/img/box-contents.avif
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7aeeca2b756297e81bcdf1e2f5d38b132f9158ef605cb4e78cc45cde41979197
-size 59856
+oid sha256:7aa86d11bf7b48b61cdc7831b3ff21280bab3fcb241694da2f6dcd7ba6ada2f0
+size 590985

--- a/src/models/launch_3b/img/ports-back.avif
+++ b/src/models/launch_3b/img/ports-back.avif
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a42af9dfe77da58840e9ed62cbdfcf7dc11bc81b77097948081d4934ac67adc6
-size 40725
+oid sha256:871c90ead82a90d520deedcbb23d39076b095514a15d6710d40fdad999dad9ff
+size 325342

--- a/src/models/launch_3b/repairs.md
+++ b/src/models/launch_3b/repairs.md
@@ -11,7 +11,7 @@ This page uses photos of the `launch_3b` revision, which is identical in structu
 
 ## Connecting and using Launch:
 
-![Launch ports](./img/ports-back.avif)
+<span class="text-on-transparency">![Launch ports](./img/ports-back.avif)</span>
 
 1. Connect the USB-C side of either the USB-C/USB-C or USB-C/USB-A cable to the Launch's center USB-C port, shown above.
 2. Connect the other side of the cable to your computer.


### PR DESCRIPTION
While working on https://github.com/system76/tech-docs/pull/349, I found where Andreina was keeping the Photoshop files for these images, so I was able to use those to export transparent versions. This replaces the opaque (white background) versions with transparent (and also higher-resolution) versions of these two images.