### PR TITLE
fix: Make links between sections fully relative

### DIFF
--- a/src/models/launch_3/repairs.md
+++ b/src/models/launch_3/repairs.md
@@ -2,7 +2,7 @@
 
 The Launch Configurable Keyboard can be customized and personalized in a variety of ways. It is recommended to unplug all USB cables and devices from your Launch before changing keycaps or switches.
 
-This page uses photos of the original `launch_3` revision, which ships with cream-colored keycaps and a grey power coat finish. For the newer black revision of this model, see the [launch_3b](/models/launch_3b/README.html).
+This page uses photos of the original `launch_3` revision, which ships with cream-colored keycaps and a grey power coat finish. For the newer black revision of this model, see the [launch_3b](../launch_3b/README.html).
 
 - [Connecting and using Launch](#connecting-and-using-launch)
 - [Removing and installing keycaps](#removing-and-installing-keycaps)

--- a/src/models/launch_3b/repairs.md
+++ b/src/models/launch_3b/repairs.md
@@ -2,7 +2,7 @@
 
 The Launch Configurable Keyboard can be customized and personalized in a variety of ways. It is recommended to unplug all USB cables and devices from your Launch before changing keycaps or switches.
 
-This page uses photos of the `launch_3b` revision, which is identical in structure and electronics to the [launch_3](/models/launch_3/README.html), but ships with black shine-through keycaps and a darker powder coat finish with top port etchings.
+This page uses photos of the `launch_3b` revision, which is identical in structure and electronics to the [launch_3](../launch_3/README.html), but ships with black shine-through keycaps and a darker powder coat finish with top port etchings.
 
 - [Connecting and using Launch](#connecting-and-using-launch)
 - [Removing and installing keycaps](#removing-and-installing-keycaps)

--- a/src/models/launch_heavy_3/repairs.md
+++ b/src/models/launch_heavy_3/repairs.md
@@ -2,7 +2,7 @@
 
 The Launch Heavy Configurable Keyboard can be customized and personalized in a variety of ways. It is recommended to unplug all USB cables and devices from your Launch Heavy before changing keycaps or switches.
 
-This page uses photos of the original `launch_heavy_3` revision, which ships with cream-colored keycaps and a grey power coat finish. For the newer black revision of this model, see the [launch_heavy_3b](/models/launch_heavy_3b/README.html).
+This page uses photos of the original `launch_heavy_3` revision, which ships with cream-colored keycaps and a grey power coat finish. For the newer black revision of this model, see the [launch_heavy_3b](../launch_heavy_3b/README.html).
 
 - [Connecting and using Launch Heavy](#connecting-and-using-launch-heavy)
 - [Removing and installing keycaps](#removing-and-installing-keycaps)

--- a/src/models/launch_heavy_3b/repairs.md
+++ b/src/models/launch_heavy_3b/repairs.md
@@ -2,7 +2,7 @@
 
 The Launch Heavy Configurable Keyboard can be customized and personalized in a variety of ways. It is recommended to unplug all USB cables and devices from your Launch Heavy before changing keycaps or switches.
 
-This page uses photos of the `launch_heavy_3b` revision, which is identical in structure and electronics to the [launch_heavy_3](/models/launch_heavy_3/README.html), but ships with black shine-through keycaps and a darker powder coat finish with top port etchings.
+This page uses photos of the `launch_heavy_3b` revision, which is identical in structure and electronics to the [launch_heavy_3](../launch_heavy_3/README.html), but ships with black shine-through keycaps and a darker powder coat finish with top port etchings.
 
 - [Connecting and using Launch Heavy](#connecting-and-using-launch-heavy)
 - [Removing and installing keycaps](#removing-and-installing-keycaps)

--- a/src/models/thelio-major-r5-n4/repairs.md
+++ b/src/models/thelio-major-r5-n4/repairs.md
@@ -2,5 +2,5 @@
 
 A service manual for the Thelio Major R5-N4 (thelio-major-r5-n4) is not yet available. Please reference the service manuals for these related models:
 
- - [Thelio Major R5-N3 (thelio-major-r5-n3)](/models/thelio-major-r5-n3/README.html) - the previous version of the Thelio Major, with similar internal components
- - [Thelio Mira R4-N4 (thelio-mira-r4-n4)](/models/thelio-mira-r4-n4/README.html) - the current version of the Thelio Mira, with a similar chassis design
+ - [Thelio Major R5-N3 (thelio-major-r5-n3)](../thelio-major-r5-n3/README.html) - the previous version of the Thelio Major, with similar internal components
+ - [Thelio Mira R4-N4 (thelio-mira-r4-n4)](../thelio-mira-r4-n4/README.html) - the current version of the Thelio Mira, with a similar chassis design

--- a/src/models/thelio-mira-r4-n3/repairs.md
+++ b/src/models/thelio-mira-r4-n3/repairs.md
@@ -1,3 +1,3 @@
 # Thelio Mira (Parts & Repairs)
 
-A service manual for the Thelio Mira R4-N3 (thelio-mira-r4-n3) is not yet available. Please reference the service manual for the previous version, the [Thelio Mira B4-N3 (thelio-mira-b4-n3)](/models/thelio-mira-b4-n3/repairs.md).
+A service manual for the Thelio Mira R4-N3 (thelio-mira-r4-n3) is not yet available. Please reference the service manual for the previous version, the [Thelio Mira B4-N3 (thelio-mira-b4-n3)](../thelio-mira-b4-n3/repairs.md).

--- a/src/models/thelio-r5-n1/repairs.md
+++ b/src/models/thelio-r5-n1/repairs.md
@@ -1,3 +1,3 @@
 # Thelio (Parts & Repairs)
 
-A service manual for the Thelio R5-N1 (thelio-r5-n1) is not yet available. Please reference the service manual for the previous version, the [Thelio R3-N1 (thelio-r3-n1)](/models/thelio-r3-n1/repairs.md).
+A service manual for the Thelio R5-N1 (thelio-r5-n1) is not yet available. Please reference the service manual for the previous version, the [Thelio R3-N1 (thelio-r3-n1)](../thelio-r3-n1/repairs.md).

--- a/src/models/thelio-spark-r3-n3/repairs.md
+++ b/src/models/thelio-spark-r3-n3/repairs.md
@@ -1,3 +1,3 @@
 # Thelio Spark (Parts & Repairs)
 
-A service manual for the Thelio Spark R3-N3 (thelio-spark-r3-n3) is not yet available. Please reference the service manual for the previous version, the [Thelio Spark B1-N2 (thelio-spark-b1-n2)](/models/thelio-spark-b1-n2/repairs.md).
+A service manual for the Thelio Spark R3-N3 (thelio-spark-r3-n3) is not yet available. Please reference the service manual for the previous version, the [Thelio Spark B1-N2 (thelio-spark-b1-n2)](../thelio-spark-b1-n2/repairs.md).


### PR DESCRIPTION
Needed to fix links after the switch from a subdomain to a subdirectory. I thought mdbook's site-url setting would take care of this for links starting with /, but their [documentation](https://rust-lang.github.io/mdBook/format/configuration/renderers.html#html-renderer-options) actually says not to use links starting with / when using the site-url setting.

Fixes #360.