### PR TITLE
ci (devcontainer): Explicitly publish port for localhost dev

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -15,6 +15,9 @@
     // Use 'forwardPorts' to make a list of ports inside the container available locally.
     // "forwardPorts": [],
 
+    // Explicitly publish port (required for Podman to forward it).
+    "runArgs": ["-p=4321:4321"],
+
     "postCreateCommand": "",
 
     "mounts": ["source=devcontainer-bash-history,target=/history,type=volume"],


### PR DESCRIPTION
This was required to get Podman to expose the port that `astro dev` runs on. With just `-p=4321`, Podman publishes it to a random local port. Without this argument, Podman wasn't exposing any ports at all, so I couldn't access the dev environment while it was running.

I first tried adding the port to devcontainer's `forwardPorts` array right above this, but that seemed to have no effect (it didn't seem to change the `docker run` command being used at all).

Docker's manpage looks like the option should be valid for Docker as well, although I haven't tested with Docker. I'm open to alternatives if there's a better one.