### PR TITLE
style: Add small border radius for images with CSS background

### DIFF
--- a/src/assets/css/img-background.css
+++ b/src/assets/css/img-background.css
@@ -4,5 +4,6 @@
         color: black; /* For image alt text */
         padding: 5px;
         margin: -5px;
+        border-radius: 5px;
     }
 }


### PR DESCRIPTION
Not sure if you or Andreina decided to nix the box-shadow used on the current site, but as an alternative to that, perhaps we can round the corners on the padding that we now add? I think this makes the affected images look a little more polished next to the fully transparent ones.