### PR TITLE
style (starlight): Slightly increase main content width

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -56,6 +56,7 @@ export default defineConfig({
             customCss: [
                 "./src/assets/css/variables.css",
                 "./src/assets/css/img-background.css",
+                "./src/assets/css/toc-width-fix.css",
             ],
             locales: {
                 root: {

--- a/src/assets/css/toc-width-fix.css
+++ b/src/assets/css/toc-width-fix.css
@@ -1,0 +1,5 @@
+/* Workaround for https://github.com/withastro/starlight/issues/3513 */
+
+.right-sidebar-panel > .sl-container {
+    padding-right: 0.75em;
+}

--- a/src/assets/css/variables.css
+++ b/src/assets/css/variables.css
@@ -1,5 +1,7 @@
-/* Dark mode colors. */
 :root {
+    --sl-content-width: 47rem;
+
+    /* Dark mode colors. */
     --sl-color-accent-low: #0c292c;
     --sl-color-accent: #007883;
     --sl-color-accent-high: #b0cfd4;
@@ -12,8 +14,9 @@
     --sl-color-gray-6: #2c251e;
     --sl-color-black: #1b1714;
 }
-/* Light mode colors. */
+
 :root[data-theme="light"] {
+    /* Light mode colors. */
     --sl-color-accent-low: #c4dcdf;
     --sl-color-accent: #00565f;
     --sl-color-accent-high: #06393f;


### PR DESCRIPTION
This uses the built-in Starlight variable to slightly increase the main content width to better match where we're coming from with mdBook, and adds a workaround for a slight ToC clipping issue (https://github.com/withastro/starlight/issues/3513).