### PR TITLE
panp16: correct Ethernet from 2.5G to 1G

### DIFF
--- a/src/models/panp16/README.md
+++ b/src/models/panp16/README.md
@@ -30,7 +30,7 @@ The System76 Pangolin is a laptop with the following specifications:
 - Memory
     - Up to 96GB (2x48GB) dual-channel DDR5 @ 5600 MHz
 - Networking
-    - 2.5-Gigabit Ethernet
+    - Gigabit Ethernet
     - M.2 PCIe WiFi 6E/Bluetooth 5.2
         - MediaTek MT7922A22M
 - Power

--- a/src/models/panp16/img/ports-right.avif
+++ b/src/models/panp16/img/ports-right.avif
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:61eac4a7b1a4c19370bc9b34ab21cc9f0e6e877b272162be97d92b831ce367c7
-size 196532
+oid sha256:2c5e1550bc24b0afbe8554a634c43c4929ebfe2397aafcc48608b1c93664a4d8
+size 192776


### PR DESCRIPTION
The catalog was incorrect too, so that is also being corrected elsewhere.