### PR TITLE
serw14: Update charger information for 290HX model

### DIFF
--- a/src/models/serw14/README.md
+++ b/src/models/serw14/README.md
@@ -51,12 +51,17 @@ The System76 Serval WS is a laptop with the following specifications:
         - Intel Wi-Fi 7 BE200
             - Bluetooth 5.4
 - Power
-    - 230W (20V, 11.5A) DC-in port
-        - Barrel size: 5.5mm (outer), 2.5mm (inner)
-    - Included AC adapter:
-        - FSP FSP230-ACBS3
-        - LiteOn PA-1231-26
-        - ...or other equivalent
+    - Core Ultra 9 290HX Plus model:
+        - 280W (20V, 14A) DC-in port
+            - Barrel size: 5.5mm (outer), 2.5mm (inner)
+        - Included AC adapter: FSP FSP280-ACAU3
+    - Core Ultra 9 275HX model:
+        - 230W (20V, 11.5A) DC-in port
+            - Barrel size: 5.5mm (outer), 2.5mm (inner)
+        - Included AC adapter:
+            - FSP FSP230-ACBS3
+            - LiteOn PA-1231-26
+            - ...or other equivalent
     - 80Wh 8-cell Lithium-Ion battery
         - Model number: X560BAT-4-80
 - Sound


### PR DESCRIPTION
I should've included this in my PR where I added the new CPU, but better late than never. The CPU update bumped the machine to a 280W charger:
<img width="4080" height="3072" alt="IMG_20260610_142757_468" src="https://github.com/user-attachments/assets/d3f6ab7e-4ada-4724-84b1-b6efc8568581" />

This can probably wait until after the Astro migration, if that makes things easier.