### PR TITLE
Add build step to verify PR build status

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,12 +5,15 @@ on:
     types: [opened, reopened, synchronize]
 
 jobs:
-  Lint:
+  Build:
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 #v6.0.3
+        with:
+          fetch-depth: 0
+          lfs: true
 
       - name: Setup pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 #v6.0.9
@@ -22,7 +25,19 @@ jobs:
           cache: pnpm
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile --dev
+        run: pnpm install --frozen-lockfile
 
       - name: Format check
         run: pnpm format:check
+
+      - name: Restore cache from S3
+        run: |
+          aws s3 cp s3://${{ secrets.STAGING_AWS_S3_BUCKET }}/cache/${{ github.event.repository.name }}/astro-cache.tar.zst astro-cache.tar.zst || true
+          tar -xf astro-cache.tar.zst --use-compress-program "zstdmt" || true
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.STAGING_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.STAGING_AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: ${{ secrets.STAGING_AWS_REGION }}
+
+      - name: Build
+        run: pnpm build


### PR DESCRIPTION
feature: add build step to verify that PR's build before merging into) master


PR for tech docs repo that renames the checks we do at ci to build to satisfy the repository requirement that a step called Build runs and passes.

Build step also updated to actually build repo instead of just performing style checks and ensuring the lock file is up to date.