### PR TITLE
Optimize CI for Dependabot PRs and bump pnpm to 11.7.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 #v6.0.3
         with:
-          fetch-depth: 0
-          lfs: true
+          fetch-depth: ${{ github.actor == 'dependabot[bot]' && 1 || 0 }}
+          lfs: ${{ github.actor != 'dependabot[bot]' }}
 
       - name: Setup pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 #v6.0.9
@@ -31,6 +31,7 @@ jobs:
         run: pnpm format:check
 
       - name: Restore cache from S3
+        if: github.actor != 'dependabot[bot]'
         run: |
           aws s3 cp s3://${{ secrets.STAGING_AWS_S3_BUCKET }}/cache/${{ github.event.repository.name }}/astro-cache.tar.zst astro-cache.tar.zst || true
           tar -xf astro-cache.tar.zst --use-compress-program "zstdmt" || true
@@ -40,4 +41,5 @@ jobs:
           AWS_DEFAULT_REGION: ${{ secrets.STAGING_AWS_REGION }}
 
       - name: Build
+        if: github.actor != 'dependabot[bot]'
         run: pnpm build

--- a/package.json
+++ b/package.json
@@ -30,5 +30,5 @@
         "prettier-plugin-astro": "^0.14.1",
         "prettier-plugin-organize-imports": "^4.3.0"
     },
-    "packageManager": "pnpm@11.5.1+sha512.93f7b57422ea7068257235b4c16eb60762eb68e1dc23723199cc739043ea9be2c4143274a399d8c6defa2b1176226d9ca1c4b63482d6200c1a8fbaa78c1d1485"
+    "packageManager": "pnpm@11.7.0+sha512.19cc852c120c7125760f2443ee6be0ca5b40f9f50598de1a09a1f177503e010e57c23c77646e01e761de59bf874fb22a3398c33ab9691fc13eb946b6f0f4d620"
 }


### PR DESCRIPTION
Reworks the CI pipeline so Dependabot PRs skip steps they don't need, and updates pnpm.

Changes to `.github/workflows/ci.yml`:

- **Checkout**: for Dependabot PRs, use `fetch-depth: 1` and skip LFS, since these PRs only need lint and lockfile validation, not the full history required for the "last updated" date plugin or LFS assets used in the build.
- **Restore cache from S3**: skip for Dependabot, since Dependabot-triggered workflow runs don't have access to repository secrets and the step would fail.
- **Build**: skip for Dependabot, since it depends on the S3 cache to complete in a reasonable time and isn't needed to validate lint/lockfile changes.

Dependabot PRs still run checkout, install (`pnpm install --frozen-lockfile` — validates the lockfile is in sync), and format check, which covers the validation needed for dependency bumps.

Also bumps `packageManager` to `pnpm@11.7.0`.