### PR TITLE
addp6: Specs

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -1,10 +1,8 @@
 # Summary
 
 - [Current Models](README.md)
-    - [Adder WS (addw5)](models/addw5/specs.md)
-        - [External Overview](models/addw5/external-overview.mdx)
-        - [Internal Overview](models/addw5/internal-overview.md)
-        - [Parts & Repairs](models/addw5/repairs.mdx)
+    - [Adder WS (addp6)](models/addp6/specs.md)
+        - [Parts & Repairs](models/addp6/repairs.mdx)
     - [Bonobo WS (bonw16)](models/bonw16/specs.md)
         - [External Overview](models/bonw16/external-overview.mdx)
         - [Internal Overview](models/bonw16/internal-overview.md)
@@ -92,6 +90,10 @@
     - [Thelio Spark (thelio-spark-r3-n3)](models/thelio-spark-r3-n3/specs.md)
         - [Parts & Repairs](models/thelio-spark-r3-n3/repairs.md)
 - [Previous Models](archive.md)
+    - [Adder WS (addw5)](models/addw5/specs.md)
+        - [External Overview](models/addw5/external-overview.mdx)
+        - [Internal Overview](models/addw5/internal-overview.md)
+        - [Parts & Repairs](models/addw5/repairs.mdx)
     - [Adder WS (addw4)](models/addw4/specs.md)
         - [External Overview](models/addw4/external-overview.mdx)
         - [Internal Overview](models/addw4/internal-overview.md)

--- a/src/content/docs/archive.md
+++ b/src/content/docs/archive.md
@@ -7,6 +7,7 @@ The source can be viewed [on GitHub](https://github.com/system76/tech-docs).
 
 ## Previous Models
 
+- [Adder WS (addw5)](models/addw5/specs.md)
 - [Adder WS (addw4)](models/addw4/specs.md)
 - [Adder WS (addw3)](models/addw3/specs.md)
 - [Adder WS (addw2)](models/addw2/specs.md)

--- a/src/content/docs/index.md
+++ b/src/content/docs/index.md
@@ -8,7 +8,7 @@ The source can be viewed [on GitHub](https://github.com/system76/tech-docs).
 
 ## Current Models
 
-- [Adder WS (addw5)](models/addw5/specs.md)
+- [Adder WS (addp6)](models/addp6/specs.md)
 - [Bonobo WS (bonw16)](models/bonw16/specs.md)
 - [Darter Pro (darp11)](models/darp11/specs.md)
 - [Eland 1U (elan1-r3)](models/elan1-r3/specs.md)

--- a/src/content/docs/models/addp6/img/addp6.avif
+++ b/src/content/docs/models/addp6/img/addp6.avif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c25a4366236a6e25883212f6ca227f89fd356a708c85e19a3a33122bc442247b
+size 404624

--- a/src/content/docs/models/addp6/repairs.mdx
+++ b/src/content/docs/models/addp6/repairs.mdx
@@ -1,0 +1,8 @@
+---
+title: Adder Pro (Parts & Repairs)
+tableOfContents:
+  minHeadingLevel: 2
+  maxHeadingLevel: 2
+---
+
+A service manual for the Adder Pro 6 (addp6) is not yet available. Please reference the service manual for the previous version, the [Adder WS 5 (addw5)](../addw5/repairs).

--- a/src/content/docs/models/addp6/specs.md
+++ b/src/content/docs/models/addp6/specs.md
@@ -1,0 +1,57 @@
+---
+title: Adder Pro (addp6)
+---
+
+![Adder WS](./img/addp6.avif)
+
+The System76 Adder WS is a laptop with the following specifications:
+
+- CPU
+    - Supports Intel Core Ultra Series 3 (Panther Lake) CPUs
+        - [Core Ultra 7 356H](https://www.intel.com/content/www/us/en/products/sku/245532/intel-core-ultra-7-processor-356h-18m-cache-up-to-4-70-ghz/specifications.html)
+- BIOS
+    - Puya PY25F256LC-WZH-IR flash chip (or equivalent)
+        - WSON-8 form factor
+    - Programmed with System76 firmware (non-open)
+- EC
+    - ITE IT5570E
+    - Programmed with non-open EC firmware
+- Graphics
+    - GPU options:
+        - NVIDIA GeForce RTX 5070
+        - NVIDIA GeForce RTX 5060
+    - eDP display: 15.3" 2560x1600@165Hz OLED
+        - OLED panel: EDO EF25QBA63.A (or equivalent)
+            - Brightness: 500 nits (cd/m²)
+            - Color coverage:
+                - Adobe RGB: 97%
+                - DCI-P3: 100%
+                - sRGB: 100%
+    - External video outputs:
+        - 1x HDMI 2.1
+        - 2x DisplayPort 1.4 over USB-C
+- Memory
+    - Up to 96GB (2x48GB) dual-channel DDR5 SO-DIMMs @ 5600 MHz
+- Networking
+    - Gigabit Ethernet
+    - M.2 PCIe/CNVi wireless card ([Intel BE211](https://www.intel.com/content/www/us/en/products/sku/240287/intel-wifi-7-r2-be211/specifications.html)):
+        - Wi-Fi 7
+        - Bluetooth 6
+- Power
+    - 230W (20V, 11.5A) DC-in port
+        - Barrel size: 5.5mm (outer), 2.5mm (inner)
+    - 60Wh 3-cell Lithium-Polymer battery
+- Sound
+    - Internal speakers & microphone
+    - Combined headphone & microphone 3.5mm jack
+    - HDMI, USB-C DisplayPort audio
+- Storage
+    - 1x M.2 PCIe NVMe Gen 4 (2280)
+    - 1x M.2 PCIe NVMe Gen 4 (2242)
+- USB
+    - 2x USB 3.2 Gen 2 Type-C
+        - Both ports support DisplayPort over USB-C
+        - Right-side port supports USB-C charging (USB-PD)
+    - 2x USB 3.2 Gen 1 Type-A
+- Dimensions
+    - 34.37cm x 26.19cm x 1.98cm, 1.5kg

--- a/src/content/docs/models/addw5/specs.md
+++ b/src/content/docs/models/addw5/specs.md
@@ -37,7 +37,6 @@ The System76 Adder WS is a laptop with the following specifications:
                 - Color coverage:
                     - DCI-P3: 74%
                     - sRGB: 100%
-                - sRGB color coverage: 100
         - 17.3" 1920x1080@144Hz LCD
             - LCD panel: Innolux N173HCE-G33 (or equivalent)
                 - Brightness: 300 nits (cd/m²)

--- a/src/content/docs/models/addw5/specs.md
+++ b/src/content/docs/models/addw5/specs.md
@@ -11,7 +11,7 @@ title: Adder WS (addw5)
 The System76 Adder WS is a laptop with the following specifications:
 
 - CPU
-    - Supports Intel Core Ultra 2nd generation (Arrow Lake) CPUs
+    - Supports Intel Core Ultra Series 2 (Arrow Lake) CPUs
         - [Core Ultra 9 275HX](https://www.intel.com/content/www/us/en/products/sku/242293/intel-core-ultra-9-processor-275hx-36m-cache-up-to-5-40-ghz/specifications.html)
 - Chipset
     - [Intel HM870](https://www.intel.com/content/www/us/en/products/sku/240123/intel-hm870-chipset/specifications.html)

--- a/src/content/docs/models/bonw16/specs.md
+++ b/src/content/docs/models/bonw16/specs.md
@@ -11,7 +11,7 @@ title: Bonobo WS (bonw16)
 The System76 Bonobo WS is a laptop with the following specifications:
 
 - CPU
-    - Supports Intel Core Ultra 2nd generation (Arrow Lake) CPUs
+    - Supports Intel Core Ultra Series 2 (Arrow Lake) CPUs
         - [Core Ultra 9 290HX Plus](https://www.intel.com/content/www/us/en/products/sku/245960/intel-core-ultra-9-processor-290hx-plus-36m-cache-up-to-5-50-ghz/specifications.html)
         - [Core Ultra 9 275HX](https://www.intel.com/content/www/us/en/products/sku/242293/intel-core-ultra-9-processor-275hx-36m-cache-up-to-5-40-ghz/specifications.html)
 - Chipset

--- a/src/content/docs/models/darp10/specs.md
+++ b/src/content/docs/models/darp10/specs.md
@@ -11,7 +11,7 @@ title: Darter Pro (darp10 & darp10-b)
 The System76 Darter Pro is a laptop with the following specifications:
 
 - CPU
-    - Supports Intel Core Ultra 1st generation (Meteor Lake) CPUs
+    - Supports Intel Core Ultra Series 1 (Meteor Lake) CPUs
         - [Core Ultra 7-155H](https://ark.intel.com/content/www/us/en/ark/products/236847/intel-core-ultra-7-processor-155h-24m-cache-up-to-4-80-ghz.html)
         - [Core Ultra 5-125H](https://ark.intel.com/content/www/us/en/ark/products/236848/intel-core-ultra-5-processor-125h-18m-cache-up-to-4-50-ghz.html)
 - BIOS

--- a/src/content/docs/models/darp11/specs.md
+++ b/src/content/docs/models/darp11/specs.md
@@ -11,7 +11,7 @@ title: Darter Pro (darp11 & darp11-b)
 The System76 Darter Pro is a laptop with the following specifications:
 
 - CPU
-    - Supports Intel Core Ultra 2nd generation (Arrow Lake) CPUs
+    - Supports Intel Core Ultra Series 2 (Arrow Lake) CPUs
         - [Core Ultra 7-255H](https://www.intel.com/content/www/us/en/products/sku/241751/intel-core-ultra-7-processor-255h-24m-cache-up-to-5-10-ghz/specifications.html)
         - [Core Ultra 5-225H](https://www.intel.com/content/www/us/en/products/sku/241749/intel-core-ultra-5-processor-225h-18m-cache-up-to-4-90-ghz/specifications.html)
 - BIOS

--- a/src/content/docs/models/gaze20/specs.md
+++ b/src/content/docs/models/gaze20/specs.md
@@ -11,7 +11,7 @@ title: Gazelle (gaze20)
 The System76 Gazelle is a laptop with the following specifications:
 
 - CPU
-    - Supports Intel Core 2nd generation (Arrow Lake) CPUs
+    - Supports Intel Core Series 2 (Arrow Lake) CPUs
         - [Core 7 250H](https://www.intel.com/content/www/us/en/products/sku/241651/intel-core-7-processor-250h-24m-cache-up-to-5-40-ghz/specifications.html)
 - Chipset
     - [Intel HM870](https://www.intel.com/content/www/us/en/products/sku/240123/intel-hm870-chipset/specifications.html)

--- a/src/content/docs/models/lemp13/specs.md
+++ b/src/content/docs/models/lemp13/specs.md
@@ -11,7 +11,7 @@ title: Lemur Pro (lemp13)
 The System76 Lemur Pro is a laptop with the following specifications:
 
 - CPU
-    - Supports Intel Core Ultra 1st generation (Meteor Lake) CPUs
+    - Supports Intel Core Ultra Series 1 (Meteor Lake) CPUs
         - [Core Ultra 7 155U](https://www.intel.com/content/www/us/en/products/sku/237327/intel-core-ultra-7-processor-155u-12m-cache-up-to-4-80-ghz/specifications.html)
         - [Core Ultra 5 125U](https://www.intel.com/content/www/us/en/products/sku/237330/intel-core-ultra-5-processor-125u-12m-cache-up-to-4-30-ghz/specifications.html)
 - BIOS

--- a/src/content/docs/models/lemp14/specs.md
+++ b/src/content/docs/models/lemp14/specs.md
@@ -7,7 +7,7 @@ title: Lemur Pro (lemp14)
 The System76 Lemur Pro is a laptop with the following specifications:
 
 - CPU
-    - Supports Intel Core Ultra 3rd generation (Panther Lake) CPUs
+    - Supports Intel Core Ultra Series 3 (Panther Lake) CPUs
         - [Core Ultra X7 358H](https://www.intel.com/content/www/us/en/products/sku/245527/intel-core-ultra-x7-processor-358h-18m-cache-up-to-4-80-ghz/specifications.html)
         - [Core Ultra 5 325](https://www.intel.com/content/www/us/en/products/sku/245720/intel-core-ultra-5-processor-325-12m-cache-up-to-4-50-ghz/specifications.html) (14" model only)
 - BIOS

--- a/src/content/docs/models/meer9/specs.md
+++ b/src/content/docs/models/meer9/specs.md
@@ -11,7 +11,7 @@ title: Meerkat (meer9)
 The System76 Meerkat is a desktop with the following specifications:
 
 - CPU
-    - Supports Intel Core Ultra 1st generation (Meteor Lake) CPUs
+    - Supports Intel Core Ultra Series 1 (Meteor Lake) CPUs
         - [Core Ultra 7 155H](https://www.intel.com/content/www/us/en/products/sku/236847/intel-core-ultra-7-processor-155h-24m-cache-up-to-4-80-ghz/specifications.html)
         - [Core Ultra 5 125H](https://www.intel.com/content/www/us/en/products/sku/236848/intel-core-ultra-5-processor-125h-18m-cache-up-to-4-50-ghz/specifications.html)
 - BIOS

--- a/src/content/docs/models/serw14/specs.md
+++ b/src/content/docs/models/serw14/specs.md
@@ -11,7 +11,7 @@ title: Serval WS (serw14)
 The System76 Serval WS is a laptop with the following specifications:
 
 - CPU
-    - Supports Intel Core Ultra 2nd generation (Arrow Lake) CPUs
+    - Supports Intel Core Ultra Series 2 (Arrow Lake) CPUs
         - [Core Ultra 9 290HX Plus](https://www.intel.com/content/www/us/en/products/sku/245960/intel-core-ultra-9-processor-290hx-plus-36m-cache-up-to-5-50-ghz/specifications.html)
         - [Core Ultra 9 275HX](https://www.intel.com/content/www/us/en/products/sku/242293/intel-core-ultra-9-processor-275hx-36m-cache-up-to-5-40-ghz/specifications.html)
 - Chipset


### PR DESCRIPTION
This adds the initial specs & placeholder repairs page for the Adder Pro 6 (addp6).

Includes a couple of other fixups for other sections.