### PR TITLE
thelio-mira-r5-n4: Add usage note for USB4

### DIFF
--- a/src/content/docs/models/thelio-mira-r5-n4/specs.md
+++ b/src/content/docs/models/thelio-mira-r5-n4/specs.md
@@ -110,6 +110,8 @@ The System76 Thelio Mira is a desktop with the following specifications:
 - USB
     - Back ports:
         - 2x USB4 Type-C
+            - USB4 ports share bandwidth (multiple high-bandwidth devices at once may have limited functionality)
+            - Connect USB4 devices before system power-on for best compatibility
         - 1x USB 3.2 Gen 2 (Type-A)
         - 5x USB 3.2 Gen 1 (Type-A)
         - 4x USB 2.0 (Type-A)


### PR DESCRIPTION
Originally:


```
Using two high bandwidth devices (eGPU, USB4 dock, etc.) on both USB4 ports may limit port capability/device functionality. We recommend connecting only one high bandwidth USB4 device to the system at a time. Some USB4 devices may not work correctly if connected _after_ powering the system on.
```

@jacobgkau refined the original into bullet points :smile: 