### PR TITLE
thelio-r5-n1 (specs): Remove ref to non-existent M.2 NVMe Gen 3 slot

### DIFF
--- a/src/content/docs/models/thelio-r5-n1/specs.md
+++ b/src/content/docs/models/thelio-r5-n1/specs.md
@@ -61,7 +61,6 @@ The System76 Thelio is a desktop with the following specifications:
 - Storage
     - 1x M.2 (PCIe NVMe Gen 5) SSD
     - 1x M.2 (PCIe NVMe Gen 4) SSD
-    - 1x M.2 (PCIe NVMe Gen 3) SSD
     - 2x 2.5" SATA
 - USB
     - Back ports:


### PR DESCRIPTION
Removed mention of 1x M.2 (PCIe NVMe Gen 3) SSD from storage specifications that is not actually on the MB.