### PR TITLE
fix (various/repairs): Use .md(x) extensions in relative links

### DIFF
--- a/src/content/docs/models/addp6/repairs.mdx
+++ b/src/content/docs/models/addp6/repairs.mdx
@@ -5,4 +5,4 @@ tableOfContents:
   maxHeadingLevel: 2
 ---
 
-A service manual for the Adder Pro 6 (addp6) is not yet available. Please reference the service manual for the previous version, the [Adder WS 5 (addw5)](../addw5/repairs).
+A service manual for the Adder Pro 6 (addp6) is not yet available. Please reference the service manual for the previous version, the [Adder WS 5 (addw5)](../addw5/repairs.mdx).

--- a/src/content/docs/models/lemp14/repairs.md
+++ b/src/content/docs/models/lemp14/repairs.md
@@ -2,4 +2,4 @@
 title: Lemur Pro (Parts & Repairs)
 ---
 
-A service manual for the Lemur Pro 14 (lemp14) is not yet available. Please reference the service manual for the previous version, the [Lemur Pro 13 (lemp13)](/tech-docs/models/lemp13/repairs).
+A service manual for the Lemur Pro 14 (lemp14) is not yet available. Please reference the service manual for the previous version, the [Lemur Pro 13 (lemp13)](../lemp13/repairs.md).

--- a/src/content/docs/models/oryp14/repairs.mdx
+++ b/src/content/docs/models/oryp14/repairs.mdx
@@ -5,4 +5,4 @@ tableOfContents:
   maxHeadingLevel: 2
 ---
 
-A service manual for the Oryx Pro 14 (oryp14) is not yet available. Please reference the service manual for the previous version, the [Oryx Pro 13 (oryp13)](../oryp13/repairs).
+A service manual for the Oryx Pro 14 (oryp14) is not yet available. Please reference the service manual for the previous version, the [Oryx Pro 13 (oryp13)](../oryp13/repairs.mdx).

--- a/src/content/docs/models/thelio-mira-r5-n4/repairs.md
+++ b/src/content/docs/models/thelio-mira-r5-n4/repairs.md
@@ -2,4 +2,4 @@
 title: Thelio Mira (Parts & Repairs)
 ---
 
-A service manual for the Thelio Mira R5-N4 (thelio-mira-r5-n4) is not yet available. Please reference the service manual for the previous model, the [Thelio Mira R4-N4 (thelio-mira-r4-n4)](../thelio-mira-r4-n4/repairs).
+A service manual for the Thelio Mira R5-N4 (thelio-mira-r5-n4) is not yet available. Please reference the service manual for the previous model, the [Thelio Mira R4-N4 (thelio-mira-r4-n4)](../thelio-mira-r4-n4/repairs.mdx).


### PR DESCRIPTION
Newly discovered Astro quirk: pages can be browsed with or without a trailing slash (or with `/index.html`), but relative links were breaking with the trailing slash since they weren't taking that extra directory layer into account (but _only_ on the live site for some reason; they worked fine when running it locally).

It appears that if we instead link to a source `.md` or `.mdx` file, Astro instead generates an absolute link that will always work. This also has the advantage of making the links work on GitHub (which is why we don't just put in absolute links ourselves).